### PR TITLE
fallback to F32 for 1-dimensional or very small tensors

### DIFF
--- a/tools/convert.py
+++ b/tools/convert.py
@@ -83,7 +83,11 @@ def handle_tensors(args, writer, state_dict):
         n_dims = len(data.shape)
         data_qtype = args.qtype
         data_shape = data.shape
-        fallback = gguf.GGMLQuantizationType.F16
+        fallback = gguf.GGMLQuantizationType.F32
+
+        # NOTE: fallback data type is F32 because many models such as Flux
+        #       are published in BF16, and BF16 --> F16 is not lossless,
+        #       while BF16 --> F32 is lossless.
 
         if n_dims == 1: 
             # these barely take up space, just use F32 / F16.
@@ -123,12 +127,12 @@ def handle_tensors(args, writer, state_dict):
         try:
             data = gguf.quants.quantize(data, data_qtype)
         except gguf.QuantError as e:
-            tqdm.write(f"falling back to F16: {e}")
-            data_qtype = gguf.GGMLQuantizationType.F16
+            tqdm.write(f"falling back to F32: {e}")
+            data_qtype = gguf.GGMLQuantizationType.F32
             data = gguf.quants.quantize(data, data_qtype)
         except AttributeError as e:
-            tqdm.write(f"falling back to F16: {e}")
-            data_qtype = gguf.GGMLQuantizationType.F16
+            tqdm.write(f"falling back to F32: {e}")
+            data_qtype = gguf.GGMLQuantizationType.F32
             data = gguf.quants.quantize(data, data_qtype)
 
         new_name = key # do we need to rename?

--- a/tools/convert.py
+++ b/tools/convert.py
@@ -136,11 +136,11 @@ def handle_tensors(args, writer, state_dict):
             data = gguf.quants.quantize(data, data_qtype)
         except gguf.QuantError as e:
             tqdm.write(f"falling back to F16: {e}")
-            data_qtype = gguf.GGMLQuantizationType.F32
+            data_qtype = gguf.GGMLQuantizationType.F16
             data = gguf.quants.quantize(data, data_qtype)
         except AttributeError as e:
             tqdm.write(f"falling back to F16: {e}")
-            data_qtype = gguf.GGMLQuantizationType.F32
+            data_qtype = gguf.GGMLQuantizationType.F16
             data = gguf.quants.quantize(data, data_qtype)
 
         new_name = key # do we need to rename?

--- a/tools/convert.py
+++ b/tools/convert.py
@@ -103,6 +103,9 @@ def handle_tensors(args, writer, state_dict):
             "final_layer.",
         ]
 
+        if any([x in key for x in blacklist]) and ".weight" in key:
+            data_qtype = fallback
+
         if n_dims == 1: 
             # one-dimensional tensors should be kept in F32
             # also speeds up inference due to not dequantizing
@@ -120,9 +123,6 @@ def handle_tensors(args, writer, state_dict):
             elif data_shape[-1] == 1: # 1x1 kernel
                 #data = np.squeeze(data) # don't do this
                 data_qtype = fallback
-
-        elif any([x in key for x in blacklist]) and ".weight" in key:
-            data_qtype = fallback
 
         # TODO: find keys to keep in higher precision(s) / qtypes
         # if "time_emb_proj.weight" in key:


### PR DESCRIPTION
Currently the fallback data type is set to F16, even when a tensor is 1-dimensional, and even when the original model was in BF16.

Using anything less than f32 for 1-dimensional tensors can cause a big loss of quality, which is why GGML / llama.cpp always use f32 for their 1-dimensional tensors. (The only exception would be if every tensor in the model was originally F16, which I have never seen.)

Additionally this solves the issue of converting BF16 --> F16, which is not lossless.

For example, in the case of FLUX.1-dev, which is natively BF16:

- `original BF16 safetensors` --> `FP16 GGUF` --> `Q8_0 GGUF`

is worse than

- `original BF16 safetensors` --> `F32 gguf or F32 safetensors` --> `Q8_0 GGUF`

I hope my explanation makes sense and I hope this contribution is useful. Thanks!