### PR TITLE
GGUF Text Encoder support

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -42,33 +42,6 @@ def gguf_sd_loader(path):
     print("\n")
     return sd
 
-class UnetLoaderGGUF:
-    @classmethod
-    def INPUT_TYPES(s):
-        unet_names = [x for x in folder_paths.get_filename_list("unet_gguf")]
-        return {
-            "required": {
-                "unet_name": (unet_names,),
-            }
-        }
-
-    RETURN_TYPES = ("MODEL",)
-    FUNCTION = "load_unet"
-    CATEGORY = "bootleg"
-    TITLE = "Unet Loader (GGUF)"
-
-    def load_unet(self, unet_name):
-        unet_path = folder_paths.get_full_path("unet", unet_name)
-        sd = gguf_sd_loader(unet_path)
-        model = comfy.sd.load_diffusion_model_state_dict(
-            sd, model_options={"custom_operations": GGMLOps}
-        )
-        if model is None:
-            logging.error("ERROR UNSUPPORTED UNET {}".format(unet_path))
-            raise RuntimeError("ERROR: Could not detect model type of: {}".format(unet_path))
-        model = GGUFModelPatcher.clone(model)
-        return (model,)
-
 # TODO: Temporary fix for now
 class GGUFModelPatcher(comfy.model_patcher.ModelPatcher):
     def calculate_weight(self, patches, weight, key):
@@ -95,6 +68,33 @@ class GGUFModelPatcher(comfy.model_patcher.ModelPatcher):
         n.backup = self.backup
         n.object_patches_backup = self.object_patches_backup
         return n
+
+class UnetLoaderGGUF:
+    @classmethod
+    def INPUT_TYPES(s):
+        unet_names = [x for x in folder_paths.get_filename_list("unet_gguf")]
+        return {
+            "required": {
+                "unet_name": (unet_names,),
+            }
+        }
+
+    RETURN_TYPES = ("MODEL",)
+    FUNCTION = "load_unet"
+    CATEGORY = "bootleg"
+    TITLE = "Unet Loader (GGUF)"
+
+    def load_unet(self, unet_name):
+        unet_path = folder_paths.get_full_path("unet", unet_name)
+        sd = gguf_sd_loader(unet_path)
+        model = comfy.sd.load_diffusion_model_state_dict(
+            sd, model_options={"custom_operations": GGMLOps}
+        )
+        if model is None:
+            logging.error("ERROR UNSUPPORTED UNET {}".format(unet_path))
+            raise RuntimeError("ERROR: Could not detect model type of: {}".format(unet_path))
+        model = GGUFModelPatcher.clone(model)
+        return (model,)
 
 NODE_CLASS_MAPPINGS = {
     "UnetLoaderGGUF": UnetLoaderGGUF,

--- a/ops.py
+++ b/ops.py
@@ -32,6 +32,13 @@ class GGMLTensor(torch.Tensor):
     def detach(self, *args, **kwargs):
         return self
 
+    def copy_(self, *args, **kwargs):
+        # fixes .weight.copy_ in comfy/clip_model/CLIPTextModel
+        try:
+            return super().copy_(*args, **kwargs)
+        except Exception as e:
+            print(f"ignoring 'copy_' on tensor")
+
     @property
     def shape(self):
         if not hasattr(self, "tensor_shape"):
@@ -44,7 +51,7 @@ class GGMLLayer(torch.nn.Module):
     """
     def __init__(self, *args, **kwargs):
         super().__init__()
-        self.weight = None
+        self.weight = GGMLTensor(1, tensor_type=None, tensor_shape=None)
         self.bias = None
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs):

--- a/ops.py
+++ b/ops.py
@@ -119,7 +119,7 @@ class GGMLLayer(torch.nn.Module):
         bias = self.get_weight(self.bias, dtype)
         return (weight, bias)
 
-class GGMLOps(comfy.ops.disable_weight_init):
+class GGMLOps(comfy.ops.manual_cast):
     """
     Dequantize weights on the fly before doing the compute
     """


### PR DESCRIPTION
This should allow using the T5 encoder in other precisions than full FP16 and FP8. On a quick test with the Q4_0 unet the results between a BF16 T5 and a [Q5_K_M](https://huggingface.co/city96/t5-v1_1-xxl-encoder-gguf/blob/main/t5-v1_1-xxl-encoder-Q5_K_M.gguf) one were [almost the same](https://imgsli.com/Mjg5MjQy) - obviously this needs more testing but preliminary results look promising.

To use it simply replace the text encoder loader with the GGUF variant. You do **not** need GGUF versions of CLIP, it can load normal models with `.safetensors`/`.bin` extensions too.

![T5_Q5_K_M](https://github.com/user-attachments/assets/d72b588f-0c76-49b3-8c91-69d756e1f8f0)
