### PR TITLE
Support loading u-net from stable-diffusion.cpp GGUF files

### DIFF
--- a/dequant.py
+++ b/dequant.py
@@ -11,7 +11,7 @@ def dequantize_tensor(tensor, dtype=None, dequant_dtype=None):
         return tensor.to(dtype)
     elif qtype in dequantize_functions:
         dequant_dtype = dtype if dequant_dtype == "target" else dequant_dtype
-        return dequantize(tensor, qtype, oshape, dtype=dequant_dtype).to(dtype)
+        return dequantize(tensor.data, qtype, oshape, dtype=dequant_dtype).to(dtype)
     else:
         # this is incredibly slow
         tqdm.write(f"Falling back to numpy dequant for qtype: {qtype}")

--- a/dequant.py
+++ b/dequant.py
@@ -3,11 +3,20 @@ import gguf
 import torch
 from tqdm import tqdm
 
+
+TORCH_COMPATIBLE_QTYPES = {None, gguf.GGMLQuantizationType.F32, gguf.GGMLQuantizationType.F16}
+
+def is_torch_compatible(tensor):
+    return tensor is None or getattr(tensor, "tensor_type", None) in TORCH_COMPATIBLE_QTYPES
+
+def is_quantized(tensor):
+    return not is_torch_compatible(tensor)
+
 def dequantize_tensor(tensor, dtype=None, dequant_dtype=None):
     qtype = getattr(tensor, "tensor_type", None)
     oshape = getattr(tensor, "tensor_shape", tensor.shape)
 
-    if qtype in (None, gguf.GGMLQuantizationType.F32, gguf.GGMLQuantizationType.F16):
+    if qtype in TORCH_COMPATIBLE_QTYPES:
         return tensor.to(dtype)
     elif qtype in dequantize_functions:
         dequant_dtype = dtype if dequant_dtype == "target" else dequant_dtype

--- a/nodes.py
+++ b/nodes.py
@@ -32,7 +32,7 @@ def gguf_sd_loader_get_orig_shape(reader, tensor_name):
         raise TypeError(f"Bad original shape metadata for {field_key}: Expected ARRAY of INT32, got {field.types}")
     return torch.Size(tuple(int(field.parts[part_idx][0]) for part_idx in field.data))
 
-def gguf_sd_loader(path, handle_prefix="model.diffusion_model.", require_prefix=False):
+def gguf_sd_loader(path, handle_prefix="model.diffusion_model."):
     """
     Read state dict as fake tensors
     """
@@ -54,8 +54,6 @@ def gguf_sd_loader(path, handle_prefix="model.diffusion_model.", require_prefix=
         has_prefix = any(s.startswith(handle_prefix) for s in tensor_names)
     else:
         has_prefix = False
-    if require_prefix and not has_prefix:
-        raise RuntimeError(f"Loader requires prefix {handle_prefix!r} which does not exist in the model")
     for tensor in reader.tensors:
         sd_key = tensor_name = tensor.name
         if has_prefix:

--- a/nodes.py
+++ b/nodes.py
@@ -67,6 +67,11 @@ def gguf_sd_loader(path, handle_prefix="model.diffusion_model.", require_prefix=
         shape = gguf_sd_loader_get_orig_shape(reader, tensor_name)
         if shape is None:
             shape = torch.Size(tuple(int(v) for v in reversed(tensor.shape)))
+            if arch_str is None and (tensor_name.endswith(".proj_in.weight") or tensor_name.endswith(".proj_out.weight")):
+                # Workaround for stable-diffusion.cpp SDXL detection.
+                # Impossible to land here for our own GGUF files as we set architecture.
+                while len(shape) > 2 and shape[-1] == 1:
+                    shape = shape[:-1]
         if tensor.tensor_type in {gguf.GGMLQuantizationType.F32, gguf.GGMLQuantizationType.F16}:
             torch_tensor = torch_tensor.view(*shape)
         sd[sd_key] = GGMLTensor(

--- a/nodes.py
+++ b/nodes.py
@@ -77,8 +77,7 @@ def gguf_sd_loader(path, handle_prefix="model.diffusion_model.", require_prefix=
         sd[sd_key] = GGMLTensor(
             torch_tensor,
             tensor_type = tensor.tensor_type,
-            tensor_shape = shape,
-            ggml_tensor_name = tensor_name,
+            tensor_shape = shape
         )
         dt[tensor_type_str] = dt.get(tensor_type_str, 0) + 1
 

--- a/ops.py
+++ b/ops.py
@@ -9,14 +9,13 @@ class GGMLTensor(torch.Tensor):
     """
     Main tensor-like class for storing quantized weights
     """
-    def __init__(self, *args, tensor_type, tensor_shape, patches=[], ggml_tensor_name=None, **kwargs):
+    def __init__(self, *args, tensor_type, tensor_shape, patches=[], **kwargs):
         super().__init__()
         self.tensor_type = tensor_type
         self.tensor_shape = tensor_shape
         self.patches = patches
-        self.ggml_tensor_name = ggml_tensor_name
 
-    def __new__(cls, *args, tensor_type, tensor_shape, patches=[], ggml_tensor_name=None, **kwargs):
+    def __new__(cls, *args, tensor_type, tensor_shape, patches=[], **kwargs):
         return super().__new__(cls, *args, **kwargs)
 
     def to(self, *args, **kwargs):
@@ -24,7 +23,6 @@ class GGMLTensor(torch.Tensor):
         new.tensor_type = getattr(self, "tensor_type", None)
         new.tensor_shape = getattr(self, "tensor_shape", new.data.shape)
         new.patches = getattr(self, "patches", []).copy()
-        new.ggml_tensor_name = getattr(self, "ggml_tensor_name", None)
         return new
 
     def clone(self, *args, **kwargs):
@@ -46,7 +44,6 @@ class GGMLTensor(torch.Tensor):
         new.tensor_type = getattr(self, "tensor_type", None)
         new.tensor_shape = getattr(self, "tensor_shape", new.data.shape)
         new.patches = getattr(self, "patches", []).copy()
-        new.ggml_tensor_name = getattr(self, "ggml_tensor_name", None)
         return new
 
     @property

--- a/ops.py
+++ b/ops.py
@@ -76,7 +76,7 @@ class GGMLLayer(torch.nn.Module):
             self.to(x.device)
 
         weight, bias = self.get_weights(x.dtype)
-        x = self._forward_operation(x, weight, bias)
+        x = self._forward_operation(x, weight, bias=bias)
         del weight, bias
 
         if device:

--- a/ops.py
+++ b/ops.py
@@ -3,7 +3,7 @@ import gguf
 import torch
 
 import comfy.ops
-from .dequant import dequantize_tensor
+from .dequant import dequantize_tensor, is_quantized
 
 class GGMLTensor(torch.Tensor):
     """
@@ -66,9 +66,7 @@ class GGMLLayer(torch.nn.Module):
             weight = self.weight
         if bias is None:
             bias = self.bias
-        weight_type = getattr(weight, "tensor_type", None)
-        bias_type = None if bias is None else getattr(bias, "tensor_type", None)
-        return any(t not in self.torch_compatible_tensor_types for t in (weight_type, bias_type))
+        return is_quantized(weight) or is_quantized(bias)
 
     def _load_from_state_dict(self, state_dict, prefix, *args, **kwargs):
         weight, bias = state_dict.get(f"{prefix}weight"), state_dict.get(f"{prefix}bias")


### PR DESCRIPTION
`stable-diffusion.cpp` quantizes some extra layer types so some more operations needed to be added. the argument parsing for those is sort of brittle, not really sure how to make it better.

they prefix their keys with `model.diffusion_model.` - maybe we should too to enable loading from GGUF checkpoints rather than just u-net, CLIP, etc separately.

some initial work to make `gguf_sd_loader` usable for loading from different key prefixes.

some other small cleanups like using tuple rather than a mutable list type for short constant sequences, avoid recalculating lengths/file lists unnecessarily. couldn't help myself, but if you want i can remove those unrelated changes.

still seems to work with the existing `GGUF` u-net files i tested with as well as output from `stable-diffusion.cpp` which has u-net, CLIP and baked VAE (but we only currently load the u-net keys).

lightly tested but theoretically could be merged in its current state.

may close #53