### PR TITLE
Sentencepiece tokenizer from gguf metadata for UMT5

### DIFF
--- a/loader.py
+++ b/loader.py
@@ -171,7 +171,10 @@ def llama_permute(raw_sd, n_head, n_head_kv):
 def gguf_tokenizer_loader(path, temb_shape):
     # convert gguf tokenizer to spiece
     print(f"Attempting to recreate sentencepiece tokenizer from GGUF file metadata...")
-    from sentencepiece import sentencepiece_model_pb2 as model
+    try:
+        from sentencepiece import sentencepiece_model_pb2 as model
+    except ImportError:
+        raise ImportError("Please make sure sentencepiece and protobuf are installed.\npip install sentencepiece protobuf")
     spm = model.ModelProto()
 
     reader = gguf.GGUFReader(path)

--- a/nodes.py
+++ b/nodes.py
@@ -186,6 +186,7 @@ CLIP_ENUM_MAP = {
     "ltxv":             "LTXV",
     "hunyuan_video":    "HUNYUAN_VIDEO",
     "pixart":           "PIXART",
+    "wan":              "WAN",
 }
 
 def get_clip_type(name):
@@ -203,7 +204,7 @@ class CLIPLoaderGGUF:
         return {
             "required": {
                 "clip_name": (s.get_filename_list(),),
-                "type": (["stable_diffusion", "stable_cascade", "sd3", "stable_audio", "mochi", "ltxv", "pixart"],),
+                "type": (["stable_diffusion", "stable_cascade", "sd3", "stable_audio", "mochi", "ltxv", "pixart", "wan"],),
             }
         }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
+# main
 gguf>=0.13.0
-
+# optional - tokenizer
+sentencepiece
+protobuf


### PR DESCRIPTION
This reconstructs the spiece tokenizer from the metadata saved in the gguf file, then adds it to the state dict in the ComfyUI specific format that the comfy-org version of the UMT5-XXL text encoder uses.

~~Still needs work, currently the token embedding (which makes up like 20% of the entire model) just causes it to OOM when it gets dequantized since it needs like 3GBs of VRAM for that operation alone.~~ For now this tensor is just dequantized beforehand for umT5.

~~Also, sentencepiece 2.0 for some reason just fails since it tries to use `google.protobuf.internal import builder as _builder`
Reuse protobuf from tokenizer class instead?~~ protobuf needs to be installed separately from spiece