### PR TITLE
Enable more `torch.compile` optimization by reducing graph breaks

### DIFF
--- a/dequant.py
+++ b/dequant.py
@@ -4,7 +4,7 @@ import torch
 from tqdm import tqdm
 
 
-TORCH_COMPATIBLE_QTYPES = {None, gguf.GGMLQuantizationType.F32, gguf.GGMLQuantizationType.F16}
+TORCH_COMPATIBLE_QTYPES = (None, gguf.GGMLQuantizationType.F32, gguf.GGMLQuantizationType.F16)
 
 def is_torch_compatible(tensor):
     return tensor is None or getattr(tensor, "tensor_type", None) in TORCH_COMPATIBLE_QTYPES


### PR DESCRIPTION
As title, there were 2 fundamental sources of graph breaks:
1. using a pre-existing set in a `torch.compile` region, this is a [known issue](https://github.com/pytorch/pytorch/issues/145761) in PyTorch and the fix is WIP, but it's a lot easier to change the set into a tuple here to fix the graph break.
2. using tensor subclass `GGMLTensor`. The full support of tensor subclass has been gated for `torch.compile`, but with [a recent WIP stack](https://github.com/pytorch/pytorch/pull/149792), we'll be able to remove the gating and have `torch.compile` fully support the `GGMLTensor` in this repo. The only required change here is avoid changing the `__class__` attribute, and instead using `torch.Tensor` to convert the subclass object back to Tensor.