### PR TITLE
LLaMA OOM hotfix

### DIFF
--- a/loader.py
+++ b/loader.py
@@ -244,8 +244,12 @@ def gguf_clip_loader(path):
     elif arch in {"llama"}:
         temb_key = "token_embd.weight"
         if temb_key in sd and sd[temb_key].shape != (128320, 4096):
-            # This still works. Raise error?
+            # This still works. TODO: Only relevant for llava?
             logging.warning("Warning! token_embd shape may be incorrect for llama 3 model!")
+        if temb_key in sd and sd[temb_key].shape[0] >= (64 * 1024):
+            # See note above for T5.
+            logging.warning(f"Dequantizing {temb_key} to prevent runtime OOM.")
+            sd[temb_key] = dequantize_tensor(sd[temb_key], dtype=torch.float16)
         sd = sd_map_replace(sd, LLAMA_SD_MAP)
         sd = llama_permute(sd, 32, 8) # L3
     else:

--- a/nodes.py
+++ b/nodes.py
@@ -114,6 +114,8 @@ class GGUFModelPatcher(comfy.model_patcher.ModelPatcher):
         self.__class__ = src_cls
         # GGUF specific clone values below
         n.patch_on_device = getattr(self, "patch_on_device", False)
+        if src_cls != GGUFModelPatcher:
+            n.size = 0 # force recalc
         return n
 
 class UnetLoaderGGUF:


### PR DESCRIPTION
Changes:
- Apply umt5 hotfix of the token embed runtime cost being too large to llama as well
- Force model size to be re-calculated after the initial patcher is loaded to avoid issue with empty linear layers not being counted