### PR TITLE
[Efficiency improvement] GGUF conversion - file caching.

### DIFF
--- a/tools/convert.py
+++ b/tools/convert.py
@@ -307,7 +307,7 @@ def convert_file(path, dst_path=None, interact=True, overwrite=False):
             raise OSError("Output exists and overwriting is disabled!")
 
     # handle actual file
-    writer = gguf.GGUFWriter(path=None, arch=model_arch.arch)
+    writer = gguf.GGUFWriter(path=None, arch=model_arch.arch, use_temp_file=True) # Cache to file.
     writer.add_quantization_version(gguf.GGML_QUANT_VERSION)
     if ftype_gguf is not None:
         writer.add_file_type(ftype_gguf)


### PR DESCRIPTION
One line fix - ggufwriter will cache to file instead of living in ram.
It's a bit slower naturally, but I think it's unreasonable to demand - what is it, 24gb ram? I get crashes on 12gb at 54% - to store a full flux model in memory, when it's a one time operation.
As mentioned in #285 , this will allow running conversions even on low resource containers (colab, space presumably).