### PR TITLE
Fix attempt to create a tensor with dtype "target"

### DIFF
--- a/ops.py
+++ b/ops.py
@@ -153,7 +153,7 @@ class GGMLLayer(torch.nn.Module):
         # Take into account space required for dequantizing the largest tensor
         if self.largest_layer:
             shape = getattr(self.weight, "tensor_shape", self.weight.shape)
-            dtype = self.dequant_dtype or torch.float16
+            dtype = (self.dequant_dtype != "target" and self.dequant_dtype) or torch.float16
             temp = torch.empty(*shape, device=torch.device("meta"), dtype=dtype)
             destination[prefix + "temp.weight"] = temp
 

--- a/ops.py
+++ b/ops.py
@@ -153,7 +153,7 @@ class GGMLLayer(torch.nn.Module):
         # Take into account space required for dequantizing the largest tensor
         if self.largest_layer:
             shape = getattr(self.weight, "tensor_shape", self.weight.shape)
-            dtype = (self.dequant_dtype != "target" and self.dequant_dtype) or torch.float16
+            dtype = (self.dequant_dtype and self.dequant_dtype != "target") or torch.float16
             temp = torch.empty(*shape, device=torch.device("meta"), dtype=dtype)
             destination[prefix + "temp.weight"] = temp
 


### PR DESCRIPTION
Currently setting `dequant_dtype` to "target" in the advanced GGUF unet loader will lead to a crash because we attempt to create an empty tensor with `dtype = "target"` which isn't a valid dtype.

This small change just uses the fallback dtype in that case. I don't know if this is the correct fix or not, but it seems to work.