### PR TITLE
Fix dequant_dtype handling

### DIFF
--- a/ops.py
+++ b/ops.py
@@ -153,7 +153,7 @@ class GGMLLayer(torch.nn.Module):
         # Take into account space required for dequantizing the largest tensor
         if self.largest_layer:
             shape = getattr(self.weight, "tensor_shape", self.weight.shape)
-            dtype = (self.dequant_dtype and self.dequant_dtype != "target") or torch.float16
+            dtype = (self.dequant_dtype != "target" and self.dequant_dtype) or torch.float16
             temp = torch.empty(*shape, device=torch.device("meta"), dtype=dtype)
             destination[prefix + "temp.weight"] = temp
 

--- a/ops.py
+++ b/ops.py
@@ -153,7 +153,7 @@ class GGMLLayer(torch.nn.Module):
         # Take into account space required for dequantizing the largest tensor
         if self.largest_layer:
             shape = getattr(self.weight, "tensor_shape", self.weight.shape)
-            dtype = (self.dequant_dtype != "target" and self.dequant_dtype) or torch.float16
+            dtype = self.dequant_dtype if self.dequant_dtype and self.dequant_dtype != "target" else torch.float16
             temp = torch.empty(*shape, device=torch.device("meta"), dtype=dtype)
             destination[prefix + "temp.weight"] = temp
 


### PR DESCRIPTION
It's back!

Unfortunately, this actually has to be the way I originally had it and we'll just have to live with the 2ns performance difference. Otherwise `self.dequant_dtype and self.dequant_dtype != "target"` ends with a truthy value when those conditionals both succeed and short-circuits there, meaning the expression evaluates to `True` which doesn't work as a dtype passed to `torch.empty`.