### PR TITLE
Triton dequantization/config framework

### DIFF
--- a/dequant.py
+++ b/dequant.py
@@ -5,17 +5,18 @@ import gguf
 import torch
 from tqdm import tqdm
 
-HAVE_TRITON=False
+HAVE_BFLOAT16=hasattr(torch, "bfloat16")
 try:
     from . import dequant_triton
     triton_dequantize_functions=dequant_triton.dequantize_functions
     HAVE_TRITON=True
 except Exception as exc:
+    HAVE_TRITON=False
     print(f"\nGGUF: Failed to enable Triton: {exc}")
     triton_dequantize_functions={}
 
 
-TORCH_COMPATIBLE_QTYPES = (None, gguf.GGMLQuantizationType.F32, gguf.GGMLQuantizationType.F16)
+TORCH_COMPATIBLE_QTYPES = frozenset((None, gguf.GGMLQuantizationType.F32, gguf.GGMLQuantizationType.F16))
 
 DequantizeHandlersType = dict[gguf.GGMLQuantizationType, Callable]
 DequantizeDtype = Optional[Union[torch.dtype, Literal["target"]]]
@@ -43,6 +44,8 @@ def dequantize_tensor(tensor, dtype=None, config: Optional[GGUFConfig]=None):
 
     if qtype in TORCH_COMPATIBLE_QTYPES:
         return tensor.to(dtype)
+    if qtype == gguf.GGMLQuantizationType.BF16 and HAVE_BFLOAT16:
+        return tensor.view(dtype=torch.bfloat16).reshape(oshape).to(dtype)
     if qtype in dequantize_functions:
         dequant_dtype = dtype if config.dequant_dtype == "target" else config.dequant_dtype
         dequantize_function = config.dequantize_function or dequantize

--- a/dequant.py
+++ b/dequant.py
@@ -1,4 +1,6 @@
 # (c) City96 || Apache-2.0 (apache.org/licenses/LICENSE-2.0)
+from typing import Callable, Literal, NamedTuple, Optional, Union
+
 import gguf
 import torch
 from tqdm import tqdm
@@ -14,33 +16,54 @@ except Exception as exc:
 
 TORCH_COMPATIBLE_QTYPES = (None, gguf.GGMLQuantizationType.F32, gguf.GGMLQuantizationType.F16)
 
+DequantizeHandlersType = dict[gguf.GGMLQuantizationType, Callable]
+DequantizeDtype = Optional[Union[torch.dtype, Literal["target"]]]
+
+class GGUFConfig(NamedTuple):
+    dequant_dtype: DequantizeDtype = None
+    patch_dtype: DequantizeDtype = None
+    patch_on_device: Optional[bool] = None
+    compile: bool = False,
+    dequantize_function: Optional[Callable] = None
+    dequantize_handlers: Optional[DequantizeHandlersType] = None
+
+DEFAULT_CONFIG = GGUFConfig()
+
 def is_torch_compatible(tensor):
     return tensor is None or getattr(tensor, "tensor_type", None) in TORCH_COMPATIBLE_QTYPES
 
 def is_quantized(tensor):
     return not is_torch_compatible(tensor)
 
-def dequantize_tensor(tensor, dtype=None, dequant_dtype=None):
+def dequantize_tensor(tensor, dtype=None, config: Optional[GGUFConfig]=None):
+    config = config or DEFAULT_CONFIG
     qtype = getattr(tensor, "tensor_type", None)
     oshape = getattr(tensor, "tensor_shape", tensor.shape)
 
     if qtype in TORCH_COMPATIBLE_QTYPES:
         return tensor.to(dtype)
     if qtype in dequantize_functions:
-        dequant_dtype = dtype if dequant_dtype == "target" else dequant_dtype
-        return dequantize(tensor.data, qtype, oshape, dtype=dequant_dtype).to(dtype)
-    else:
-        # this is incredibly slow
-        tqdm.write(f"Falling back to numpy dequant for qtype: {getattr(qtype, 'name', repr(qtype))}")
-        new = gguf.quants.dequantize(tensor.cpu().numpy(), qtype)
-        return torch.from_numpy(new).to(tensor.device, dtype=dtype)
+        # print(f"\nGGUF: DEQUANT: {qtype}: config={config}")
+        dequant_dtype = dtype if config.dequant_dtype == "target" else config.dequant_dtype
+        dequantize_function = config.dequantize_function or dequantize
+        return dequantize_function(
+            tensor.data,
+            qtype,
+            oshape,
+            dtype=dequant_dtype,
+            dequantize_functions_override=config.dequantize_handlers,
+        ).to(dtype)
+    # this is incredibly slow
+    tqdm.write(f"Falling back to numpy dequant for qtype: {getattr(qtype, 'name', repr(qtype))}")
+    new = gguf.quants.dequantize(tensor.cpu().numpy(), qtype)
+    return torch.from_numpy(new).to(tensor.device, dtype=dtype)
 
-def dequantize(data, qtype, oshape, dtype=None):
+def dequantize(data, qtype, oshape, dtype=None, dequantize_functions_override: Optional[DequantizeHandlersType]=None):
     """
     Dequantize tensor back to usable shape/dtype
     """
     block_size, type_size = gguf.GGML_QUANT_SIZES[qtype]
-    dequantize_blocks = (ALLOW_TRITON and triton_dequantize_functions.get(qtype)) or dequantize_functions[qtype]
+    dequantize_blocks = (dequantize_functions_override or dequantize_functions)[qtype]
 
     rows = data.reshape(
         (-1, data.shape[-1])

--- a/dequant.py
+++ b/dequant.py
@@ -13,6 +13,7 @@ try:
 except Exception as exc:
     HAVE_TRITON=False
     print(f"\nGGUF: Failed to enable Triton: {exc}")
+    dequant_triton = None
     triton_dequantize_functions={}
 
 
@@ -25,7 +26,7 @@ class GGUFConfig(NamedTuple):
     dequant_dtype: DequantizeDtype = None
     patch_dtype: DequantizeDtype = None
     patch_on_device: Optional[bool] = None
-    optimize: str = "none"
+    optimize: frozenset[str] = frozenset()
     dequantize_function: Optional[Callable] = None
     dequantize_handlers: Optional[DequantizeHandlersType] = None
 

--- a/dequant.py
+++ b/dequant.py
@@ -105,7 +105,7 @@ def dequantize_blocks_Q5_1(blocks, block_size, type_size, dtype=None):
     d, m, qh, qs = split_block_dims(blocks, 2, 2, 4)
     d = d.view(torch.float16).to(dtype)
     m = m.view(torch.float16).to(dtype)
-    qh = to_uint32(qh)
+    qh = qh.contiguous().view(torch.int32)
 
     qh = qh.reshape((n_blocks, 1)) >> torch.arange(32, device=d.device, dtype=torch.int32).reshape(1, 32)
     ql = qs.reshape((n_blocks, -1, 1, block_size // 2)) >> torch.tensor([0, 4], device=d.device, dtype=torch.uint8).reshape(1, 1, 2, 1)
@@ -120,7 +120,7 @@ def dequantize_blocks_Q5_0(blocks, block_size, type_size, dtype=None):
 
     d, qh, qs = split_block_dims(blocks, 2, 4)
     d  = d.view(torch.float16).to(dtype)
-    qh = to_uint32(qh)
+    qh = qh.contiguous().view(torch.int32)
 
     qh = qh.reshape(n_blocks, 1) >> torch.arange(32, device=d.device, dtype=torch.int32).reshape(1, 32)
     ql = qs.reshape(n_blocks, -1, 1, block_size // 2) >> torch.tensor([0, 4], device=d.device, dtype=torch.uint8).reshape(1, 1, 2, 1)

--- a/dequant_triton.py
+++ b/dequant_triton.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field as dcfield
-from typing import Any, Callable, NamedTuple, TypeVar, cast
+from typing import Any, NamedTuple
 
 import torch
 import triton

--- a/dequant_triton.py
+++ b/dequant_triton.py
@@ -3,161 +3,67 @@ import torch
 import triton
 import triton.language as tl
 
-import gguf
+from gguf import GGML_QUANT_SIZES, QK_K, GGMLQuantizationType
 
-TORCH_TO_TRITON_DTYPE_MAP = {
+K_SCALE_SIZE = 12
+
+TORCH_TO_TRITON_DTYPE_MAP: dict[torch.dtype, tl.dtype] = {
     torch.float32: tl.float32,
     torch.float16: tl.float16,
     torch.bfloat16: tl.bfloat16,
 }
 
-# K Quants #
-QK_K = 256
-K_SCALE_SIZE = 12
+_DEFAULT_AUTOTUNE_CONFIGS: list[triton.Config] = [
+    triton.Config({"N_BLOCKS_PER_PROG": 1}, num_warps=4),
+    triton.Config({"N_BLOCKS_PER_PROG": 2}, num_warps=4),
+    triton.Config({"N_BLOCKS_PER_PROG": 4}, num_warps=4),
+    triton.Config({"N_BLOCKS_PER_PROG": 1}, num_warps=8),
+    triton.Config({"N_BLOCKS_PER_PROG": 2}, num_warps=8),
+    triton.Config({"N_BLOCKS_PER_PROG": 4}, num_warps=8),
+]
 
-
-@triton.autotune(
-    configs=[
-        # Test different numbers of GGUF blocks per program instance
-        triton.Config({"N_BLOCKS_PER_PROG": 1}, num_warps=4),
-        triton.Config({"N_BLOCKS_PER_PROG": 2}, num_warps=4),
-        triton.Config({"N_BLOCKS_PER_PROG": 4}, num_warps=4),
-        triton.Config({"N_BLOCKS_PER_PROG": 8}, num_warps=4),
-        triton.Config({"N_BLOCKS_PER_PROG": 1}, num_warps=8),
-        triton.Config({"N_BLOCKS_PER_PROG": 2}, num_warps=8),
-        triton.Config({"N_BLOCKS_PER_PROG": 4}, num_warps=8),
-        triton.Config({"N_BLOCKS_PER_PROG": 8}, num_warps=8),
-    ],
-    key=["n_total_blocks"],  # Tune based on the total number of blocks
-)
-@triton.jit
-def dequantize_q8_0_kernel(
-    q_tensor_ptr,
-    out_tensor_ptr,
-    n_total_blocks,
-    GGUF_BLOCK_SIZE: tl.constexpr,
-    GGUF_TYPE_SIZE: tl.constexpr,
-    N_BLOCKS_PER_PROG: tl.constexpr,  # How many blocks each program handles
-    OUT_DTYPE: tl.constexpr,
-):
-    out_dtype = OUT_DTYPE.value
-
-    # Each program is responsible for a chunk of N_BLOCKS_PER_PROG blocks
-    pid = tl.program_id(axis=0)
-
-    # Starting GGUF block index for this program
-    start_block_idx = pid * N_BLOCKS_PER_PROG
-
-    # Create offsets for the weights within a GGUF block (0, 1, ..., 31)
-    weight_indices = tl.arange(0, GGUF_BLOCK_SIZE)
-
-    # Loop over the N blocks assigned to this program
-    for i in tl.static_range(N_BLOCKS_PER_PROG):
-        current_block_idx = start_block_idx + i
-
-        # Boundary check to avoid processing padding blocks
-        if current_block_idx < n_total_blocks:
-            # Pointer to the start of the current GGUF block in the input tensor
-            block_start_ptr = q_tensor_ptr + current_block_idx * GGUF_TYPE_SIZE
-
-            # Load scale (d)
-            uint16_ptr = block_start_ptr.to(tl.pointer_type(tl.uint16))
-            uint16_val = tl.load(uint16_ptr)
-            scale_fp16 = tl.cast(uint16_val, tl.float16, bitcast=True)
-            scale = scale_fp16.to(out_dtype)
-
-            # Load weights (x)
-            q_weights_ptr = block_start_ptr + 2
-            uint8_weights = tl.load(q_weights_ptr + weight_indices)
-            q_weights = uint8_weights.to(tl.int8)
-
-            # Dequantize
-            dequantized_weights = q_weights.to(out_dtype) * scale
-
-            # Store the result
-            output_start_ptr = out_tensor_ptr + current_block_idx * GGUF_BLOCK_SIZE
-            tl.store(output_start_ptr + weight_indices, dequantized_weights)
-
-
-def dequantize_blocks_Q8_0_triton(
-    blocks: torch.Tensor,
-    block_size: int,
-    type_size: int,
-    dtype=None,
-) -> torch.Tensor:
-    assert blocks.dtype == torch.uint8 and blocks.is_cuda and blocks.is_contiguous()
-
-    n_elements = blocks.numel()
-    assert n_elements % type_size == 0
-    n_total_blocks = n_elements // type_size
-
-    dtype = dtype or torch.float32
-    triton_dtype = TORCH_TO_TRITON_DTYPE_MAP.get(dtype)
-    if triton_dtype is None:
-        raise TypeError(f"Unsupported output dtype {dtype}")
-
-    out_tensor = torch.empty(
-        (n_total_blocks * block_size,),
-        dtype=dtype,
-        device=blocks.device,
-    )
-
-    def grid(meta):
-        return (triton.cdiv(n_total_blocks, meta["N_BLOCKS_PER_PROG"]),)
-
-    dequantize_q8_0_kernel[grid](
-        blocks,
-        out_tensor,
-        n_total_blocks,
-        GGUF_BLOCK_SIZE=block_size,
-        GGUF_TYPE_SIZE=type_size,
-        OUT_DTYPE=triton_dtype,
-    )
-
-    return out_tensor.reshape(n_total_blocks, -1)
+_AUTOTUNE_CONFIGS: dict[str, list[triton.Config]] = {}
 
 
 @triton.jit
-def dequantize_q4_k_get_scales_min(
+def dequantize_Q4_K_get_scales_min(
     k_idx: int,
     d_sc_word: tl.tensor,
     m_word: tl.tensor,
     m_sc_word: tl.tensor,
-) -> tuple[tl.tensor, tl.tensor]:
+) -> tl.tuple:
     if k_idx < 4:
         k_idx_x8 = k_idx * 8
         d_sc_byte = d_sc_word >> k_idx_x8
         m_byte = m_word >> k_idx_x8
-        return d_sc_byte & 0x3F, m_byte & 0x3F
+        sc = d_sc_byte & 0x3F
+        m = m_byte & 0x3F
+    else:
+        k_prime_x8 = (k_idx - 4) * 8
+        d_sc_byte = d_sc_word >> k_prime_x8
+        m_byte = m_word >> k_prime_x8
+        m_sc_byte = m_sc_word >> k_prime_x8
+        sc = (m_sc_byte & 0x0F) | ((d_sc_byte >> 2) & 0x30)
+        m = ((m_sc_byte & 0xFF) >> 4) | ((m_byte >> 2) & 0x30)
+    return tl.tuple((sc, m))
 
-    k_prime_x8 = (k_idx - 4) * 8
-    d_sc_byte = d_sc_word >> k_prime_x8
-    m_byte = m_word >> k_prime_x8
-    m_sc_byte = (m_sc_word >> k_prime_x8) & 0xFF
-    sc = (m_sc_byte & 0x0F) | ((d_sc_byte >> 2) & 0x30)
-    m = (m_sc_byte >> 4) | ((m_byte >> 2) & 0x30)
-    return sc, m
+
+# Same as Q4_K
+dequantize_Q5_K_get_scales_min = dequantize_Q4_K_get_scales_min
 
 
 @triton.autotune(
-    configs=[
-        triton.Config({"N_BLOCKS_PER_PROG": 1}, num_warps=4),
-        triton.Config({"N_BLOCKS_PER_PROG": 2}, num_warps=4),
-        triton.Config({"N_BLOCKS_PER_PROG": 4}, num_warps=4),
-        triton.Config({"N_BLOCKS_PER_PROG": 1}, num_warps=8),
-        triton.Config({"N_BLOCKS_PER_PROG": 2}, num_warps=8),
-        triton.Config({"N_BLOCKS_PER_PROG": 4}, num_warps=8),
-    ],
+    configs=_AUTOTUNE_CONFIGS.get("q4_k", _DEFAULT_AUTOTUNE_CONFIGS),
     key=["n_total_blocks"],
 )
 @triton.jit
-def dequantize_q4_k_kernel(
+def dequantize_Q4_K_kernel(
     q_tensor_ptr,
     out_tensor_ptr,
     n_total_blocks,
     OUT_DTYPE: tl.constexpr,
-    TYPE_SIZE: tl.constexpr,
     N_BLOCKS_PER_PROG: tl.constexpr,
+    TYPE_SIZE: tl.constexpr,
     QK_K: tl.constexpr = QK_K,
     K_SCALE_SIZE: tl.constexpr = K_SCALE_SIZE,
 ):
@@ -165,14 +71,14 @@ def dequantize_q4_k_kernel(
     pid = tl.program_id(axis=0)
     start_block_idx = pid * N_BLOCKS_PER_PROG
 
-    qs_chunk_offsets = tl.arange(0, 32)
-    store_offsets = tl.arange(0, 32)
+    offsets_32 = tl.arange(0, 32)
+    offsets_scale = offsets_32 + 4 + K_SCALE_SIZE
 
     for i in tl.static_range(N_BLOCKS_PER_PROG):
         current_block_idx = start_block_idx + i
         if current_block_idx < n_total_blocks:
             block_start_ptr = q_tensor_ptr + current_block_idx * TYPE_SIZE
-            output_start_ptr = out_tensor_ptr + current_block_idx * QK_K
+            output_start_ptr = out_tensor_ptr + current_block_idx * QK_K + offsets_32
 
             d = tl.load(block_start_ptr.to(tl.pointer_type(tl.float16))).to(out_dtype)
             dmin = tl.load((block_start_ptr + 2).to(tl.pointer_type(tl.float16))).to(
@@ -184,19 +90,19 @@ def dequantize_q4_k_kernel(
             m_word = tl.load(scales_ptr_u32 + 1)
             m_sc_word = tl.load(scales_ptr_u32 + 2)
 
-            qs_start_ptr = block_start_ptr + 4 + K_SCALE_SIZE
+            qs_start_ptr = block_start_ptr + offsets_scale
 
             # Process in 4 chunks of 64 values
             for k_chunk in tl.static_range(4):
                 k_idx = 2 * k_chunk
 
                 # --- Get scale A (for low nibbles) ---
-                sc_a, m_a = dequantize_q4_k_get_scales_min(
+                sc_a, m_a = dequantize_Q4_K_get_scales_min(
                     k_idx, d_sc_word, m_word, m_sc_word
                 )
 
                 # --- Get scale B (for high nibbles) ---
-                sc_b, m_b = dequantize_q4_k_get_scales_min(
+                sc_b, m_b = dequantize_Q4_K_get_scales_min(
                     k_idx + 1, d_sc_word, m_word, m_sc_word
                 )
 
@@ -207,7 +113,7 @@ def dequantize_q4_k_kernel(
 
                 # Load 32 bytes of quantized data
                 chunk_qs_ptr = qs_start_ptr + k_chunk * 32
-                qs_bytes_chunk = tl.load(chunk_qs_ptr + qs_chunk_offsets)
+                qs_bytes_chunk = tl.load(chunk_qs_ptr)
 
                 qs_low = (qs_bytes_chunk & 0x0F).to(out_dtype)
                 qs_high = (qs_bytes_chunk >> 4).to(out_dtype)
@@ -217,79 +123,38 @@ def dequantize_q4_k_kernel(
 
                 # Store results contiguously
                 output_chunk_ptr = output_start_ptr + k_chunk * 64
-                tl.store(output_chunk_ptr + store_offsets, dequant_low)
-                tl.store(output_chunk_ptr + 32 + store_offsets, dequant_high)
-
-
-def dequantize_blocks_Q4_K_triton(
-    blocks: torch.Tensor,
-    block_size: int,
-    type_size: int,
-    dtype=None,
-) -> torch.Tensor:
-    assert blocks.dtype == torch.uint8 and blocks.is_cuda and blocks.is_contiguous()
-
-    n_elements = blocks.numel()
-    assert n_elements % type_size == 0
-    n_total_blocks = n_elements // type_size
-
-    dtype = dtype or torch.float32
-    triton_dtype = TORCH_TO_TRITON_DTYPE_MAP.get(dtype)
-    if triton_dtype is None:
-        raise TypeError(f"Unsupported output dtype {dtype}")
-
-    out_tensor = torch.empty(
-        (n_total_blocks * QK_K,), dtype=dtype, device=blocks.device
-    )
-
-    def grid(meta):
-        return (triton.cdiv(n_total_blocks, meta["N_BLOCKS_PER_PROG"]),)
-
-    dequantize_q4_k_kernel[grid](
-        blocks,
-        out_tensor,
-        n_total_blocks,
-        TYPE_SIZE=type_size,
-        OUT_DTYPE=triton_dtype,
-    )
-
-    return out_tensor.reshape(n_total_blocks, -1)
+                output_chunk_ptr.store(dequant_low)
+                (output_chunk_ptr + 32).store(dequant_high)
 
 
 @triton.autotune(
-    configs=[
-        triton.Config({"N_BLOCKS_PER_PROG": 1}, num_warps=4),
-        triton.Config({"N_BLOCKS_PER_PROG": 2}, num_warps=4),
-        triton.Config({"N_BLOCKS_PER_PROG": 4}, num_warps=4),
-        triton.Config({"N_BLOCKS_PER_PROG": 1}, num_warps=8),
-        triton.Config({"N_BLOCKS_PER_PROG": 2}, num_warps=8),
-        triton.Config({"N_BLOCKS_PER_PROG": 4}, num_warps=8),
-    ],
+    configs=_AUTOTUNE_CONFIGS.get("q5_k", _DEFAULT_AUTOTUNE_CONFIGS),
     key=["n_total_blocks"],
 )
 @triton.jit
-def dequantize_q5_k_kernel(
+def dequantize_Q5_K_kernel(
     q_tensor_ptr,
     out_tensor_ptr,
     n_total_blocks,
-    QK_K: tl.constexpr,
-    TYPE_SIZE: tl.constexpr,
-    K_SCALE_SIZE: tl.constexpr,
     OUT_DTYPE: tl.constexpr,
     N_BLOCKS_PER_PROG: tl.constexpr,
+    TYPE_SIZE: tl.constexpr,
+    QK_K: tl.constexpr = QK_K,
+    K_SCALE_SIZE: tl.constexpr = K_SCALE_SIZE,
 ):
     out_dtype = OUT_DTYPE.value
     pid = tl.program_id(axis=0)
     start_block_idx = pid * N_BLOCKS_PER_PROG
 
     offsets_32 = tl.arange(0, 32)
+    offsets_scale = offsets_32 + 4 + K_SCALE_SIZE
 
     for i in tl.static_range(N_BLOCKS_PER_PROG):
         current_block_idx = start_block_idx + i
         if current_block_idx < n_total_blocks:
             # Pointers and initial loads
             block_start_ptr = q_tensor_ptr + current_block_idx * TYPE_SIZE
-            output_start_ptr = out_tensor_ptr + current_block_idx * QK_K
+            output_start_ptr = out_tensor_ptr + current_block_idx * QK_K + offsets_32
             d = tl.load(block_start_ptr.to(tl.pointer_type(tl.float16))).to(out_dtype)
             dmin = tl.load((block_start_ptr + 2).to(tl.pointer_type(tl.float16))).to(
                 out_dtype
@@ -300,31 +165,24 @@ def dequantize_q5_k_kernel(
             m_word = tl.load(scales_ptr_u32 + 1)
             m_sc_word = tl.load(scales_ptr_u32 + 2)
 
-            qh_start_ptr = block_start_ptr + 4 + K_SCALE_SIZE
+            qh_start_ptr = block_start_ptr + offsets_scale
             qs_start_ptr = qh_start_ptr + QK_K // 8
 
-            qh_bytes_all = tl.load(qh_start_ptr + offsets_32)
+            qh_bytes_all = tl.load(qh_start_ptr)
 
             # Process in 8 chunks of 32 values
             for chunk_idx in tl.static_range(8):
-                # 1. Unpack scale and min for this chunk
-                if chunk_idx < 4:
-                    sc = ((d_sc_word >> (chunk_idx * 8)) & 0xFF) & 0x3F
-                    m = ((m_word >> (chunk_idx * 8)) & 0xFF) & 0x3F
-                else:
-                    k_prime = chunk_idx - 4
-                    d_sc_byte = (d_sc_word >> (k_prime * 8)) & 0xFF
-                    m_byte = (m_word >> (k_prime * 8)) & 0xFF
-                    m_sc_byte = (m_sc_word >> (k_prime * 8)) & 0xFF
-                    sc = (m_sc_byte & 0x0F) | ((d_sc_byte >> 2) & 0x30)
-                    m = (m_sc_byte >> 4) | ((m_byte >> 2) & 0x30)
+                # # 1. Unpack scale and min for this chunk
+                sc, m = dequantize_Q5_K_get_scales_min(
+                    chunk_idx, d_sc_word, m_word, m_sc_word
+                )
 
                 final_d = d * sc.to(out_dtype)
                 final_dm = dmin * m.to(out_dtype)
 
                 # 2. Unpack ql (lower 4 bits) for this chunk
                 qs_byte_offset = (chunk_idx // 2) * 32
-                qs_bytes = tl.load(qs_start_ptr + qs_byte_offset + offsets_32)
+                qs_bytes = tl.load(qs_start_ptr + qs_byte_offset)
                 use_low_nibbles = chunk_idx % 2 == 0
                 ql = tl.where(use_low_nibbles, qs_bytes & 0x0F, qs_bytes >> 4)
 
@@ -336,66 +194,22 @@ def dequantize_q5_k_kernel(
                 dequant_32 = final_d * q.to(out_dtype) - final_dm
 
                 output_ptr = output_start_ptr + chunk_idx * 32
-                tl.store(output_ptr + offsets_32, dequant_32)
-
-
-def dequantize_blocks_Q5_K_triton(
-    blocks: torch.Tensor,
-    block_size: int,
-    type_size: int,
-    dtype=None,
-) -> torch.Tensor:
-    assert blocks.dtype == torch.uint8 and blocks.is_cuda and blocks.is_contiguous()
-
-    n_elements = blocks.numel()
-    assert n_elements % type_size == 0
-    n_total_blocks = n_elements // type_size
-
-    dtype = dtype or torch.float32
-    triton_dtype = TORCH_TO_TRITON_DTYPE_MAP.get(dtype)
-    if triton_dtype is None:
-        raise TypeError(f"Unsupported output dtype {dtype}")
-
-    out_tensor = torch.empty(
-        (n_total_blocks * QK_K,), dtype=dtype, device=blocks.device
-    )
-
-    def grid(meta):
-        return (triton.cdiv(n_total_blocks, meta["N_BLOCKS_PER_PROG"]),)
-
-    dequantize_q5_k_kernel[grid](
-        blocks,
-        out_tensor,
-        n_total_blocks,
-        QK_K=QK_K,
-        TYPE_SIZE=type_size,
-        K_SCALE_SIZE=K_SCALE_SIZE,
-        OUT_DTYPE=triton_dtype,
-    )
-
-    return out_tensor.reshape(n_total_blocks, -1)
+                output_ptr.store(dequant_32)
 
 
 @triton.autotune(
-    configs=[
-        triton.Config({"N_BLOCKS_PER_PROG": 1}, num_warps=4),
-        triton.Config({"N_BLOCKS_PER_PROG": 2}, num_warps=4),
-        triton.Config({"N_BLOCKS_PER_PROG": 4}, num_warps=4),
-        triton.Config({"N_BLOCKS_PER_PROG": 1}, num_warps=8),
-        triton.Config({"N_BLOCKS_PER_PROG": 2}, num_warps=8),
-        triton.Config({"N_BLOCKS_PER_PROG": 4}, num_warps=8),
-    ],
+    configs=_AUTOTUNE_CONFIGS.get("q6_k", _DEFAULT_AUTOTUNE_CONFIGS),
     key=["n_total_blocks"],
 )
 @triton.jit
-def dequantize_q6_k_kernel(
+def dequantize_Q6_K_kernel(
     q_tensor_ptr,
     out_tensor_ptr,
     n_total_blocks,
-    QK_K: tl.constexpr,
-    TYPE_SIZE: tl.constexpr,
     OUT_DTYPE: tl.constexpr,
     N_BLOCKS_PER_PROG: tl.constexpr,
+    TYPE_SIZE: tl.constexpr,
+    QK_K: tl.constexpr = QK_K,
 ):
     out_dtype = OUT_DTYPE.value
     pid = tl.program_id(axis=0)
@@ -451,48 +265,73 @@ def dequantize_q6_k_kernel(
                 tl.store(output_ptr + offsets_32, dequant_32)
 
 
-def dequantize_blocks_Q6_K_triton(
-    blocks: torch.Tensor,
-    block_size: int,
-    type_size: int,
-    dtype=None,
-) -> torch.Tensor:
-    assert blocks.dtype == torch.uint8 and blocks.is_cuda and blocks.is_contiguous()
+def dequantize_blocks_triton_wrapper_factory(
+    qtype: GGMLQuantizationType,
+    kernel,
+):
+    ggml_type_size = GGML_QUANT_SIZES[qtype][1]
 
-    n_elements = blocks.numel()
-    assert n_elements % type_size == 0
-    n_total_blocks = n_elements // type_size
+    def dequantize_blocks_triton(
+        blocks: torch.Tensor,
+        block_size: int,
+        type_size: int,
+        dtype=None,
+    ) -> torch.Tensor:
+        if blocks.dtype != torch.uint8:
+            raise ValueError(
+                f"GGUF Triton {qtype.name}: Blocks tensor dtype must be uint8 but got {blocks.dtype}"
+            )
+        if not blocks.is_cuda:
+            raise ValueError(f"GGUF Triton {qtype.name}: Blocks tensor must be CUDA")
+        if not blocks.is_contiguous():
+            raise ValueError(
+                f"GGUF Triton {qtype.name}: Blocks tensor must be contiguous"
+            )
 
-    dtype = dtype or torch.float32
-    triton_dtype = TORCH_TO_TRITON_DTYPE_MAP.get(dtype)
-    if triton_dtype is None:
-        raise TypeError(f"Unsupported output dtype {dtype}")
+        n_elements = blocks.numel()
+        if n_elements % ggml_type_size != 0:
+            raise ValueError(
+                f"GGUF Triton {qtype.name}: Blocks tensor must have a number of elements ({n_elements}) divisible by the type size {ggml_type_size}"
+            )
+        n_total_blocks = n_elements // ggml_type_size
 
-    out_tensor = torch.empty(
-        (n_total_blocks * QK_K,), dtype=dtype, device=blocks.device
-    )
+        dtype = dtype or torch.float32
+        triton_dtype = TORCH_TO_TRITON_DTYPE_MAP.get(dtype)
+        if triton_dtype is None:
+            raise TypeError(
+                f"GGUF Triton {qtype.name}: Unsupported output dtype {dtype}"
+            )
 
-    def grid(meta):
-        return (triton.cdiv(n_total_blocks, meta["N_BLOCKS_PER_PROG"]),)
+        out_tensor = torch.empty(
+            (n_total_blocks * QK_K,), dtype=dtype, device=blocks.device
+        )
 
-    dequantize_q6_k_kernel[grid](
-        blocks,
-        out_tensor,
-        n_total_blocks,
-        QK_K=QK_K,
-        TYPE_SIZE=type_size,
-        OUT_DTYPE=triton_dtype,
-    )
+        def grid(meta: dict):
+            return (triton.cdiv(n_total_blocks, meta["N_BLOCKS_PER_PROG"]),)
 
-    return out_tensor.reshape(n_total_blocks, -1)
+        kernel[grid](
+            blocks,
+            out_tensor,
+            n_total_blocks,
+            TYPE_SIZE=ggml_type_size,
+            OUT_DTYPE=triton_dtype,
+        )
+
+        return out_tensor.reshape(n_total_blocks, -1)
+
+    return dequantize_blocks_triton
 
 
 dequantize_functions = {
-    # Q8_0 simply seems than the PyTorch implementation.
-    # gguf.GGMLQuantizationType.Q8_0: dequantize_blocks_Q8_0_triton,
-    gguf.GGMLQuantizationType.Q4_K: dequantize_blocks_Q4_K_triton,
-    gguf.GGMLQuantizationType.Q5_K: dequantize_blocks_Q5_K_triton,
-    gguf.GGMLQuantizationType.Q6_K: dequantize_blocks_Q6_K_triton,
+    GGMLQuantizationType.Q4_K: dequantize_blocks_triton_wrapper_factory(
+        GGMLQuantizationType.Q4_K, dequantize_Q4_K_kernel
+    ),
+    GGMLQuantizationType.Q5_K: dequantize_blocks_triton_wrapper_factory(
+        GGMLQuantizationType.Q5_K, dequantize_Q5_K_kernel
+    ),
+    GGMLQuantizationType.Q6_K: dequantize_blocks_triton_wrapper_factory(
+        GGMLQuantizationType.Q6_K, dequantize_Q6_K_kernel
+    ),
 }
 
 __all__ = ("dequantize_functions",)

--- a/dequant_triton.py
+++ b/dequant_triton.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, NamedTuple
+from dataclasses import dataclass, field as dcfield
+from typing import Any, Callable, NamedTuple, TypeVar, cast
 
 import torch
 import triton
@@ -29,27 +30,79 @@ _DEFAULT_AUTOTUNE_CONFIGS: list[triton.Config] = [
 _AUTOTUNE_CONFIGS: dict[str, list[triton.Config]] = {}
 
 
+@dataclass
+class KernelImpl:
+    type_size: tl.constexpr
+    block_size: tl.constexpr
+
+    def get_autotuner(self, **kwargs: dict) -> triton.runtime.Autotuner:
+        return triton.autotune(**kwargs)(self.dequantize_kernel)
+
+    @staticmethod
+    @triton.jit
+    def dequantize_kernel(
+        q_tensor_ptr,
+        out_tensor_ptr,
+        n_total_blocks,
+        OUT_DTYPE: tl.constexpr,
+        N_BLOCKS_PER_PROG: tl.constexpr,
+        CTX: tl.constexpr,
+    ) -> None:
+        pid = tl.program_id(axis=0)
+        start_block_idx = pid * N_BLOCKS_PER_PROG
+
+        n_blocks = n_total_blocks - start_block_idx
+
+        if n_blocks > 0:
+            block_start_ptr = q_tensor_ptr + start_block_idx * CTX.type_size
+            output_start_ptr = out_tensor_ptr + start_block_idx * CTX.block_size
+
+            for i in tl.static_range(N_BLOCKS_PER_PROG):
+                if i < n_blocks:
+                    # Pointer to the i-th quantized block
+                    current_q_ptr = block_start_ptr + i * CTX.type_size
+                    # Pointer to the i-th output block
+                    current_out_ptr = output_start_ptr + i * CTX.block_size
+
+                    # Call the core helper with a stride of 1 for contiguous output
+                    CTX.dequantize_block_kernel(
+                        current_q_ptr,
+                        current_out_ptr,
+                        CTX=CTX,
+                        OUT_DTYPE=OUT_DTYPE,
+                    )
+
+
 class KernelDefinition(NamedTuple):
     qtype: GGMLQuantizationType
-    kernel: triton.runtime.Autotuner
     block_size: int
     type_size: int
-    kernel_kwargs: dict[str, Any]
+    kernel: KernelImpl
+    autotuner_kernel: triton.runtime.Autotuner
 
     @classmethod
     def build(
         cls,
         qtype: GGMLQuantizationType,
-        kernel: triton.runtime.Autotuner,
-        **kwargs: dict[str, Any],
+        kernel_class: type[KernelImpl],
     ) -> "KernelDefinition":
         block_size, type_size = GGML_QUANT_SIZES[qtype]
+        kernel_instance = kernel_class(
+            block_size=tl.constexpr(block_size),
+            type_size=tl.constexpr(type_size),
+        )
+        autotuner_kernel = kernel_instance.get_autotuner(
+            configs=_AUTOTUNE_CONFIGS.get(
+                qtype.name.lower(), _DEFAULT_AUTOTUNE_CONFIGS
+            ),
+            key=["n_total_blocks"],
+        )
         return cls(
             qtype=qtype,
-            kernel=kernel,
             block_size=block_size,
             type_size=type_size,
-            kernel_kwargs=kwargs,
+            kernel=kernel_instance,
+            autotuner_kernel=autotuner_kernel,
         )
 
     def __call__(
@@ -61,9 +114,12 @@ class KernelDefinition(NamedTuple):
     ) -> torch.Tensor:
         qtype, ggml_type_size = self.qtype, self.type_size
         if blocks.dtype != torch.uint8:
-            raise ValueError(
-                f"GGUF Triton {qtype.name}: Blocks tensor dtype must be uint8 but got {blocks.dtype}"
-            )
+            if blocks.dtype == torch.int8:
+                blocks = blocks.view(dtype=torch.uint8)
+            else:
+                raise ValueError(
+                    f"GGUF Triton {qtype.name}: Blocks tensor dtype must be uint8 or int8 but got {blocks.dtype}"
+                )
         if not blocks.is_cuda:
             raise ValueError(f"GGUF Triton {qtype.name}: Blocks tensor must be CUDA")
         if not blocks.is_contiguous():
@@ -91,14 +147,12 @@ class KernelDefinition(NamedTuple):
         def grid(meta: dict[str, Any]) -> tuple[int]:
             return (triton.cdiv(n_total_blocks, meta["N_BLOCKS_PER_PROG"]),)
 
-        self.kernel[grid](
+        self.autotuner_kernel[grid](
             blocks,
             out_tensor,
             n_total_blocks,
-            BLOCK_SIZE=self.block_size,
-            TYPE_SIZE=ggml_type_size,
+            CTX=self.kernel,
             OUT_DTYPE=triton_dtype,
-            **self.kernel_kwargs,
         )
 
         return out_tensor
@@ -107,678 +161,513 @@ class KernelDefinition(NamedTuple):
 ### K-quants
 
 
-@triton.autotune(
-    configs=_AUTOTUNE_CONFIGS.get("q2_k", _DEFAULT_AUTOTUNE_CONFIGS),
-    key=["n_total_blocks"],
-)
-@triton.jit
-def dequantize_Q2_K_kernel(
-    q_tensor_ptr,
-    out_tensor_ptr,
-    n_total_blocks,
-    OUT_DTYPE: tl.constexpr,
-    N_BLOCKS_PER_PROG: tl.constexpr,
-    TYPE_SIZE: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
-) -> None:
-    out_dtype = OUT_DTYPE.value
-    pid = tl.program_id(axis=0)
-    start_block_idx = pid * N_BLOCKS_PER_PROG
+@dataclass
+class KernelImpl_K_Quant(KernelImpl):
+    k_scale_size: tl.constexpr = dcfield(
+        default_factory=lambda: tl.constexpr(K_SCALE_SIZE)
+    )
 
-    # Vector of offsets for a 16-element chunk
-    offsets_16 = tl.arange(0, 16)
 
-    for i in tl.static_range(N_BLOCKS_PER_PROG):
-        current_block_idx = start_block_idx + i
-        if current_block_idx < n_total_blocks:
-            # --- Set up pointers for the current block ---
-            block_start_ptr = q_tensor_ptr + current_block_idx * TYPE_SIZE
+@dataclass
+class KernelImpl_Q2_K(KernelImpl_K_Quant):
+    @staticmethod
+    @triton.jit
+    def dequantize_block_kernel(
+        block_start_ptr,
+        out_tensor_ptr,
+        CTX: tl.constexpr,
+        OUT_DTYPE: tl.constexpr,
+    ) -> None:
+        # Vector of offsets for a 16-element chunk
+        offsets_16 = tl.arange(0, 16)
 
-            # Data layout for Q2_K (TYPE_SIZE = 84 bytes)
-            scales_ptr = block_start_ptr
-            qs_ptr = block_start_ptr + 16
-            d_ptr = block_start_ptr + 80
-            dmin_ptr = block_start_ptr + 82
+        # Data layout for Q2_K (TYPE_SIZE = 84 bytes)
+        scales_ptr = block_start_ptr
+        qs_ptr = block_start_ptr + 16
+        d_ptr = block_start_ptr + 80
+        dmin_ptr = block_start_ptr + 82
 
-            # --- Load the super-scales 'd' and 'dmin' ---
-            d = tl.load(d_ptr.to(tl.pointer_type(tl.float16))).to(out_dtype)
-            dmin = tl.load(dmin_ptr.to(tl.pointer_type(tl.float16))).to(out_dtype)
+        # --- Load the super-scales 'd' and 'dmin' ---
+        d = tl.load(d_ptr.to(tl.pointer_type(tl.float16))).to(OUT_DTYPE)
+        dmin = tl.load(dmin_ptr.to(tl.pointer_type(tl.float16))).to(OUT_DTYPE)
 
-            # --- Process block in 16 chunks of 16 values ---
-            for chunk_idx in tl.static_range(16):
-                # 1. Unpack the scales for this chunk.
-                # Each of the 16 scale bytes corresponds to a 16-element chunk.
-                # The low nibble scales 'd', the high nibble scales 'dmin'.
-                scale_byte = tl.load(scales_ptr + chunk_idx)
+        # --- Process block in 16 chunks of 16 values ---
+        for chunk_idx in tl.static_range(16):
+            # 1. Unpack the scales for this chunk.
+            # Each of the 16 scale bytes corresponds to a 16-element chunk.
+            # The low nibble scales 'd', the high nibble scales 'dmin'.
+            scale_byte = tl.load(scales_ptr + chunk_idx)
 
-                dl = d * (scale_byte & 0x0F).to(out_dtype)
-                ml = dmin * (scale_byte >> 4).to(out_dtype)
+            dl = d * (scale_byte & 0x0F).to(OUT_DTYPE)
+            ml = dmin * (scale_byte >> 4).to(OUT_DTYPE)
 
-                # --- Map the 16 output elements to their source data ---
-                # This logic correctly models the Python reshape from a flat 256-element array.
-                flat_indices = chunk_idx * 16 + offsets_16
+            # --- Map the 16 output elements to their source data ---
+            # This logic correctly models the Python reshape from a flat 256-element array.
+            flat_indices = chunk_idx * 16 + offsets_16
 
-                # 2. Unpack the 2-bit quantized values (qs).
-                # The logical source array for qs is (2 segments * 4 shifts * 32 bytes).
-                source_row = flat_indices // 32
-                source_col = flat_indices % 32
+            # 2. Unpack the 2-bit quantized values (qs).
+            # The logical source array for qs is (2 segments * 4 shifts * 32 bytes).
+            source_row = flat_indices // 32
+            source_col = flat_indices % 32
 
-                segment = source_row // 4
-                shift_group = source_row % 4
+            segment = source_row // 4
+            shift_group = source_row % 4
 
-                # Gather bytes from their calculated source pointers
-                ptr = qs_ptr + segment * 32 + source_col
-                byte = tl.load(ptr)
+            # Gather bytes from their calculated source pointers
+            ptr = qs_ptr + segment * 32 + source_col
+            byte = tl.load(ptr)
 
-                # Apply the correct bit shift to extract the 2-bit value
-                q_vec = (byte >> (shift_group * 2)) & 3
+            # Apply the correct bit shift to extract the 2-bit value
+            q_vec = (byte >> (shift_group * 2)) & 3
 
-                # 3. Dequantize and store the 16 results.
-                dequant_16 = dl * q_vec.to(out_dtype) - ml
+            # 3. Dequantize and store the 16 results.
+            dequant_16 = dl * q_vec.to(OUT_DTYPE) - ml
 
-                output_ptr = (
-                    out_tensor_ptr + current_block_idx * BLOCK_SIZE + chunk_idx * 16
+            output_ptr = out_tensor_ptr + chunk_idx * 16
+            tl.store(output_ptr + offsets_16, dequant_16)
+
+
+@dataclass
+class KernelImpl_Q3_K(KernelImpl_K_Quant):
+    @staticmethod
+    @triton.jit
+    def dequantize_block_kernel(
+        block_start_ptr,
+        out_tensor_ptr,
+        CTX: tl.constexpr,
+        OUT_DTYPE: tl.constexpr,
+    ) -> None:
+        # Vector of offsets for a 16-element chunk (one row of the output matrix)
+        offsets_16 = tl.arange(0, 16)
+
+        hmask_ptr = block_start_ptr
+        qs_ptr = block_start_ptr + 32
+        scales_ptr = block_start_ptr + 96
+        d_ptr = block_start_ptr + 108
+
+        # --- Load the super-scale 'd' ---
+        d_super_scale = tl.load(d_ptr.to(tl.pointer_type(tl.float16))).to(OUT_DTYPE)
+
+        # --- Process block in 16 chunks of 16 values ---
+        for chunk_idx in tl.static_range(16):
+            # 1. Unpack the 6-bit scale for this chunk.
+
+            # Low 4 bits of the scale (lscale_nibble)
+            lscale_byte_index = chunk_idx % 8
+            lscale_shift = (chunk_idx // 8) * 4
+            lscale_byte = tl.load(scales_ptr + lscale_byte_index)
+            lscale_nibble = (lscale_byte >> lscale_shift) & 0x0F
+
+            # High 2 bits of the scale (hscale_2bit)
+            hscale_byte_index = chunk_idx % 4
+            hscale_shift_index = chunk_idx // 4
+            hscale_byte = tl.load(scales_ptr + 8 + hscale_byte_index)
+            hscale_2bit = (hscale_byte >> (hscale_shift_index * 2)) & 0x03
+
+            scale_6bit = lscale_nibble | (hscale_2bit << 4)
+            final_scale = d_super_scale * (
+                scale_6bit.to(tl.int8, bitcast=True) - 32
+            ).to(OUT_DTYPE)
+
+            # --- Map the 16 output elements to their source data ---
+            flat_indices = chunk_idx * 16 + offsets_16
+
+            # 2. Unpack ql (lower 2 bits).
+            ql_source_row = flat_indices // 32
+            ql_source_col = flat_indices % 32
+
+            ql_segment = ql_source_row // 4
+            ql_shift_group = ql_source_row % 4
+
+            ql_ptr = qs_ptr + ql_segment * 32 + ql_source_col
+            ql_byte = tl.load(ql_ptr)
+            ql_vec = ((ql_byte >> (ql_shift_group * 2)) & 3).to(tl.int8, bitcast=True)
+
+            # 3. Unpack qh (higher 1 bit, inverted).
+            qh_source_row = flat_indices // 32
+            qh_source_col = flat_indices % 32
+
+            qh_ptr = hmask_ptr + qh_source_col
+            qh_byte = tl.load(qh_ptr)
+            qh_vec = (((qh_byte >> qh_source_row) & 1) ^ 1).to(tl.int8, bitcast=True)
+
+            # 4. Combine to get the final 3-bit quantized value.
+            q_vec = ql_vec - (qh_vec << 2)
+
+            # 5. Dequantize and store the 16 results.
+            dequant_16 = final_scale * q_vec.to(OUT_DTYPE)
+            output_ptr = out_tensor_ptr + chunk_idx * 16 + offsets_16
+            tl.store(output_ptr, dequant_16)
+
+
+@dataclass
+class KernelImpl_Q4_K(KernelImpl_K_Quant):
+    # Helper function, shared by Q4_K and Q5_K.
+    @staticmethod
+    @triton.jit
+    def get_scales_min(
+        k_idx: int,
+        d_sc_word: tl.tensor,
+        m_word: tl.tensor,
+        m_sc_word: tl.tensor,
+    ) -> tl.tuple:
+        if k_idx < 4:
+            k_idx_x8 = k_idx * 8
+            d_sc_byte = d_sc_word >> k_idx_x8
+            m_byte = m_word >> k_idx_x8
+            sc = d_sc_byte & 0x3F
+            m = m_byte & 0x3F
+        else:
+            k_prime_x8 = (k_idx - 4) * 8
+            d_sc_byte = d_sc_word >> k_prime_x8
+            m_byte = m_word >> k_prime_x8
+            m_sc_byte = m_sc_word >> k_prime_x8
+            sc = (m_sc_byte & 0x0F) | ((d_sc_byte >> 2) & 0x30)
+            m = ((m_sc_byte & 0xFF) >> 4) | ((m_byte >> 2) & 0x30)
+        return tl.tuple((sc, m))
+
+    @staticmethod
+    @triton.jit
+    def dequantize_block_kernel(
+        block_start_ptr,
+        out_tensor_ptr,
+        CTX: tl.constexpr,
+        OUT_DTYPE: tl.constexpr,
+    ) -> None:
+        offsets_32 = tl.arange(0, 32)
+        offsets_scale = offsets_32 + 4 + CTX.k_scale_size
+
+        d = tl.load(block_start_ptr.to(tl.pointer_type(tl.float16))).to(OUT_DTYPE)
+        dmin = tl.load((block_start_ptr + 2).to(tl.pointer_type(tl.float16))).to(
+            OUT_DTYPE
+        )
+
+        scales_ptr_u32 = (block_start_ptr + 4).to(tl.pointer_type(tl.uint32))
+        d_sc_word = tl.load(scales_ptr_u32 + 0)
+        m_word = tl.load(scales_ptr_u32 + 1)
+        m_sc_word = tl.load(scales_ptr_u32 + 2)
+
+        qs_start_ptr = block_start_ptr + offsets_scale
+
+        # Process in 4 chunks of 64 values
+        for k_chunk in tl.static_range(4):
+            k_idx = 2 * k_chunk
+
+            # --- Get scale A (for low nibbles) ---
+            sc_a, m_a = CTX.get_scales_min(k_idx, d_sc_word, m_word, m_sc_word)
+
+            # --- Get scale B (for high nibbles) ---
+            sc_b, m_b = CTX.get_scales_min(k_idx + 1, d_sc_word, m_word, m_sc_word)
+
+            current_d_a = d * sc_a.to(OUT_DTYPE)
+            current_dm_a = dmin * m_a.to(OUT_DTYPE)
+            current_d_b = d * sc_b.to(OUT_DTYPE)
+            current_dm_b = dmin * m_b.to(OUT_DTYPE)
+
+            # Load 32 bytes of quantized data
+            chunk_qs_ptr = qs_start_ptr + k_chunk * 32
+            qs_bytes_chunk = tl.load(chunk_qs_ptr)
+
+            qs_low = (qs_bytes_chunk & 0x0F).to(OUT_DTYPE)
+            qs_high = (qs_bytes_chunk >> 4).to(OUT_DTYPE)
+
+            dequant_low = current_d_a * qs_low - current_dm_a
+            dequant_high = current_d_b * qs_high - current_dm_b
+
+            # Store results contiguously
+            output_chunk_ptr = out_tensor_ptr + k_chunk * 64 + offsets_32
+            output_chunk_ptr.store(dequant_low)
+            (output_chunk_ptr + 32).store(dequant_high)
+
+
+@dataclass
+class KernelImpl_Q5_K(KernelImpl_Q4_K):
+    @staticmethod
+    @triton.jit
+    def dequantize_block_kernel(
+        block_start_ptr,
+        out_tensor_ptr,
+        CTX: tl.constexpr,
+        OUT_DTYPE: tl.constexpr,
+    ) -> None:
+        offsets_32 = tl.arange(0, 32)
+        offsets_scale = offsets_32 + 4 + CTX.k_scale_size
+
+        # Pointers and initial loads
+        d = tl.load(block_start_ptr.to(tl.pointer_type(tl.float16))).to(OUT_DTYPE)
+        dmin = tl.load((block_start_ptr + 2).to(tl.pointer_type(tl.float16))).to(
+            OUT_DTYPE
+        )
+
+        scales_ptr_u32 = (block_start_ptr + 4).to(tl.pointer_type(tl.uint32))
+        d_sc_word = tl.load(scales_ptr_u32 + 0)
+        m_word = tl.load(scales_ptr_u32 + 1)
+        m_sc_word = tl.load(scales_ptr_u32 + 2)
+
+        qh_start_ptr = block_start_ptr + offsets_scale
+        qs_start_ptr = qh_start_ptr + CTX.block_size // 8
+
+        qh_bytes_all = tl.load(qh_start_ptr)
+
+        # Process in 8 chunks of 32 values
+        for chunk_idx in tl.static_range(8):
+            # # 1. Unpack scale and min for this chunk
+            sc, m = CTX.get_scales_min(chunk_idx, d_sc_word, m_word, m_sc_word)
+
+            final_d = d * sc.to(OUT_DTYPE)
+            final_dm = dmin * m.to(OUT_DTYPE)
+
+            # 2. Unpack ql (lower 4 bits) for this chunk
+            qs_byte_offset = (chunk_idx // 2) * 32
+            qs_bytes = tl.load(qs_start_ptr + qs_byte_offset)
+            use_low_nibbles = chunk_idx % 2 == 0
+            ql = tl.where(use_low_nibbles, qs_bytes & 0x0F, qs_bytes >> 4)
+
+            # 3. Unpack qh (higher 1 bit) for this chunk
+            qh = (qh_bytes_all >> chunk_idx) & 0x01
+
+            # 4. Combine, dequantize, and store
+            q = ql | (qh << 4)
+            dequant_32 = final_d * q.to(OUT_DTYPE) - final_dm
+
+            output_ptr = out_tensor_ptr + chunk_idx * 32 + offsets_32
+            output_ptr.store(dequant_32)
+
+
+@dataclass
+class KernelImpl_Q6_K(KernelImpl_K_Quant):
+    @staticmethod
+    @triton.jit
+    def dequantize_block_kernel(
+        block_start_ptr,
+        out_tensor_ptr,
+        CTX: tl.constexpr,
+        OUT_DTYPE: tl.constexpr,
+    ) -> None:
+        offsets_32 = tl.arange(0, 32)
+        mask_16 = offsets_32 < 16
+
+        d_ptr = block_start_ptr + 208
+        scales_ptr = block_start_ptr + 192
+        d_super_scale = tl.load(d_ptr.to(tl.pointer_type(tl.float16))).to(OUT_DTYPE)
+
+        # Process block in 8 chunks of 32 values
+        for chunk_idx in tl.static_range(8):
+            # 1. Calculate ql source data and unpack
+            ql_byte_offset = (chunk_idx % 2) * 32 + (chunk_idx // 4) * 64
+            ql_ptr = block_start_ptr + ql_byte_offset
+            ql_32_bytes = tl.load(ql_ptr + offsets_32)
+
+            use_low_nibbles = (chunk_idx // 2) % 2 == 0
+            ql_vec_32 = ql_32_bytes & 0x0F if use_low_nibbles else ql_32_bytes >> 4
+            ql_vec_32 = ql_vec_32.to(tl.int8, bitcast=True)
+
+            # 2. Calculate qh source data and unpack
+            qh_byte_offset = (chunk_idx // 4) * 32
+            qh_ptr = block_start_ptr + 128 + qh_byte_offset
+
+            bit_shift = (chunk_idx % 4) * 2
+            qh_32_bytes = tl.load(qh_ptr + offsets_32)
+            qh_vec_32 = (qh_32_bytes.to(tl.int8, bitcast=True) >> bit_shift) & 0x03
+
+            # 3. Combine and dequantize
+            q_vec_32 = ((ql_vec_32 | (qh_vec_32 << 4)) - 32).to(OUT_DTYPE)
+
+            # 4. Load and apply correct scales
+            scale_0_ptr = scales_ptr + chunk_idx * 2
+            scales_0_1 = (
+                tl.where(
+                    mask_16,
+                    tl.load(scale_0_ptr),
+                    tl.load(scale_0_ptr + 1),
                 )
-                tl.store(output_ptr + offsets_16, dequant_16)
-
-
-@triton.autotune(
-    configs=_AUTOTUNE_CONFIGS.get("q3_k", _DEFAULT_AUTOTUNE_CONFIGS),
-    key=["n_total_blocks"],
-)
-@triton.jit
-def dequantize_Q3_K_kernel(
-    q_tensor_ptr,
-    out_tensor_ptr,
-    n_total_blocks,
-    OUT_DTYPE: tl.constexpr,
-    N_BLOCKS_PER_PROG: tl.constexpr,
-    TYPE_SIZE: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
-) -> None:
-    out_dtype = OUT_DTYPE.value
-    pid = tl.program_id(axis=0)
-    start_block_idx = pid * N_BLOCKS_PER_PROG
-
-    # Vector of offsets for a 16-element chunk (one row of the output matrix)
-    offsets_16 = tl.arange(0, 16)
-
-    for i in tl.static_range(N_BLOCKS_PER_PROG):
-        current_block_idx = start_block_idx + i
-        if current_block_idx < n_total_blocks:
-            # --- Set up pointers for the current block ---
-            block_start_ptr = q_tensor_ptr + current_block_idx * TYPE_SIZE
-            output_start_ptr = out_tensor_ptr + current_block_idx * BLOCK_SIZE
-
-            hmask_ptr = block_start_ptr
-            qs_ptr = block_start_ptr + 32
-            scales_ptr = block_start_ptr + 96
-            d_ptr = block_start_ptr + 108
-
-            # --- Load the super-scale 'd' ---
-            d_super_scale = tl.load(d_ptr.to(tl.pointer_type(tl.float16))).to(out_dtype)
-
-            # --- Process block in 16 chunks of 16 values ---
-            for chunk_idx in tl.static_range(16):
-                # 1. Unpack the 6-bit scale for this chunk.
-
-                # Low 4 bits of the scale (lscale_nibble)
-                lscale_byte_index = chunk_idx % 8
-                lscale_shift = (chunk_idx // 8) * 4
-                lscale_byte = tl.load(scales_ptr + lscale_byte_index)
-                lscale_nibble = (lscale_byte >> lscale_shift) & 0x0F
-
-                # High 2 bits of the scale (hscale_2bit)
-                hscale_byte_index = chunk_idx % 4
-                hscale_shift_index = chunk_idx // 4
-                hscale_byte = tl.load(scales_ptr + 8 + hscale_byte_index)
-                hscale_2bit = (hscale_byte >> (hscale_shift_index * 2)) & 0x03
-
-                scale_6bit = lscale_nibble | (hscale_2bit << 4)
-                final_scale = d_super_scale * (scale_6bit.to(tl.int8) - 32).to(
-                    out_dtype
-                )
-
-                # --- Map the 16 output elements to their source data ---
-                flat_indices = chunk_idx * 16 + offsets_16
-
-                # 2. Unpack ql (lower 2 bits).
-                ql_source_row = flat_indices // 32
-                ql_source_col = flat_indices % 32
-
-                ql_segment = ql_source_row // 4
-                ql_shift_group = ql_source_row % 4
-
-                ql_ptr = qs_ptr + ql_segment * 32 + ql_source_col
-                ql_byte = tl.load(ql_ptr)
-                ql_vec = ((ql_byte >> (ql_shift_group * 2)) & 3).to(tl.int8)
-
-                # 3. Unpack qh (higher 1 bit, inverted).
-                qh_source_row = flat_indices // 32
-                qh_source_col = flat_indices % 32
-
-                qh_ptr = hmask_ptr + qh_source_col
-                qh_byte = tl.load(qh_ptr)
-                qh_vec = (((qh_byte >> qh_source_row) & 1) ^ 1).to(tl.int8)
-
-                # 4. Combine to get the final 3-bit quantized value.
-                q_vec = ql_vec - (qh_vec << 2)
-
-                # 5. Dequantize and store the 16 results.
-                dequant_16 = final_scale * q_vec.to(out_dtype)
-                output_ptr = output_start_ptr + chunk_idx * 16
-                tl.store(output_ptr + offsets_16, dequant_16)
-
-
-# Helper function, shared by Q4_K and Q5_K.
-@triton.jit
-def dequantize_Q4_K_Q5_K_get_scales_min(
-    k_idx: int,
-    d_sc_word: tl.tensor,
-    m_word: tl.tensor,
-    m_sc_word: tl.tensor,
-) -> tl.tuple:
-    if k_idx < 4:
-        k_idx_x8 = k_idx * 8
-        d_sc_byte = d_sc_word >> k_idx_x8
-        m_byte = m_word >> k_idx_x8
-        sc = d_sc_byte & 0x3F
-        m = m_byte & 0x3F
-    else:
-        k_prime_x8 = (k_idx - 4) * 8
-        d_sc_byte = d_sc_word >> k_prime_x8
-        m_byte = m_word >> k_prime_x8
-        m_sc_byte = m_sc_word >> k_prime_x8
-        sc = (m_sc_byte & 0x0F) | ((d_sc_byte >> 2) & 0x30)
-        m = ((m_sc_byte & 0xFF) >> 4) | ((m_byte >> 2) & 0x30)
-    return tl.tuple((sc, m))
-
-
-@triton.autotune(
-    configs=_AUTOTUNE_CONFIGS.get("q4_k", _DEFAULT_AUTOTUNE_CONFIGS),
-    key=["n_total_blocks"],
-)
-@triton.jit
-def dequantize_Q4_K_kernel(
-    q_tensor_ptr,
-    out_tensor_ptr,
-    n_total_blocks,
-    OUT_DTYPE: tl.constexpr,
-    N_BLOCKS_PER_PROG: tl.constexpr,
-    TYPE_SIZE: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
-    K_SCALE_SIZE: tl.constexpr,
-    get_scales_min: tl.constexpr,
-) -> None:
-    out_dtype = OUT_DTYPE.value
-    pid = tl.program_id(axis=0)
-    start_block_idx = pid * N_BLOCKS_PER_PROG
-
-    offsets_32 = tl.arange(0, 32)
-    offsets_scale = offsets_32 + 4 + K_SCALE_SIZE
-
-    for i in tl.static_range(N_BLOCKS_PER_PROG):
-        current_block_idx = start_block_idx + i
-        if current_block_idx < n_total_blocks:
-            block_start_ptr = q_tensor_ptr + current_block_idx * TYPE_SIZE
-            output_start_ptr = (
-                out_tensor_ptr + current_block_idx * BLOCK_SIZE + offsets_32
+                .to(tl.int8, bitcast=True)
+                .to(OUT_DTYPE)
             )
+            scales_32 = d_super_scale * scales_0_1
+            dequant_32 = q_vec_32 * scales_32
 
-            d = tl.load(block_start_ptr.to(tl.pointer_type(tl.float16))).to(out_dtype)
-            dmin = tl.load((block_start_ptr + 2).to(tl.pointer_type(tl.float16))).to(
-                out_dtype
-            )
-
-            scales_ptr_u32 = (block_start_ptr + 4).to(tl.pointer_type(tl.uint32))
-            d_sc_word = tl.load(scales_ptr_u32 + 0)
-            m_word = tl.load(scales_ptr_u32 + 1)
-            m_sc_word = tl.load(scales_ptr_u32 + 2)
-
-            qs_start_ptr = block_start_ptr + offsets_scale
-
-            # Process in 4 chunks of 64 values
-            for k_chunk in tl.static_range(4):
-                k_idx = 2 * k_chunk
-
-                # --- Get scale A (for low nibbles) ---
-                sc_a, m_a = get_scales_min(k_idx, d_sc_word, m_word, m_sc_word)
-
-                # --- Get scale B (for high nibbles) ---
-                sc_b, m_b = get_scales_min(k_idx + 1, d_sc_word, m_word, m_sc_word)
-
-                current_d_a = d * sc_a.to(out_dtype)
-                current_dm_a = dmin * m_a.to(out_dtype)
-                current_d_b = d * sc_b.to(out_dtype)
-                current_dm_b = dmin * m_b.to(out_dtype)
-
-                # Load 32 bytes of quantized data
-                chunk_qs_ptr = qs_start_ptr + k_chunk * 32
-                qs_bytes_chunk = tl.load(chunk_qs_ptr)
-
-                qs_low = (qs_bytes_chunk & 0x0F).to(out_dtype)
-                qs_high = (qs_bytes_chunk >> 4).to(out_dtype)
-
-                dequant_low = current_d_a * qs_low - current_dm_a
-                dequant_high = current_d_b * qs_high - current_dm_b
-
-                # Store results contiguously
-                output_chunk_ptr = output_start_ptr + k_chunk * 64
-                output_chunk_ptr.store(dequant_low)
-                (output_chunk_ptr + 32).store(dequant_high)
-
-
-@triton.autotune(
-    configs=_AUTOTUNE_CONFIGS.get("q5_k", _DEFAULT_AUTOTUNE_CONFIGS),
-    key=["n_total_blocks"],
-)
-@triton.jit
-def dequantize_Q5_K_kernel(
-    q_tensor_ptr,
-    out_tensor_ptr,
-    n_total_blocks,
-    OUT_DTYPE: tl.constexpr,
-    N_BLOCKS_PER_PROG: tl.constexpr,
-    TYPE_SIZE: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
-    K_SCALE_SIZE: tl.constexpr,
-    get_scales_min: tl.constexpr,
-) -> None:
-    out_dtype = OUT_DTYPE.value
-    pid = tl.program_id(axis=0)
-    start_block_idx = pid * N_BLOCKS_PER_PROG
-
-    offsets_32 = tl.arange(0, 32)
-    offsets_scale = offsets_32 + 4 + K_SCALE_SIZE
-
-    for i in tl.static_range(N_BLOCKS_PER_PROG):
-        current_block_idx = start_block_idx + i
-        if current_block_idx < n_total_blocks:
-            # Pointers and initial loads
-            block_start_ptr = q_tensor_ptr + current_block_idx * TYPE_SIZE
-            output_start_ptr = (
-                out_tensor_ptr + current_block_idx * BLOCK_SIZE + offsets_32
-            )
-            d = tl.load(block_start_ptr.to(tl.pointer_type(tl.float16))).to(out_dtype)
-            dmin = tl.load((block_start_ptr + 2).to(tl.pointer_type(tl.float16))).to(
-                out_dtype
-            )
-
-            scales_ptr_u32 = (block_start_ptr + 4).to(tl.pointer_type(tl.uint32))
-            d_sc_word = tl.load(scales_ptr_u32 + 0)
-            m_word = tl.load(scales_ptr_u32 + 1)
-            m_sc_word = tl.load(scales_ptr_u32 + 2)
-
-            qh_start_ptr = block_start_ptr + offsets_scale
-            qs_start_ptr = qh_start_ptr + BLOCK_SIZE // 8
-
-            qh_bytes_all = tl.load(qh_start_ptr)
-
-            # Process in 8 chunks of 32 values
-            for chunk_idx in tl.static_range(8):
-                # # 1. Unpack scale and min for this chunk
-                sc, m = get_scales_min(chunk_idx, d_sc_word, m_word, m_sc_word)
-
-                final_d = d * sc.to(out_dtype)
-                final_dm = dmin * m.to(out_dtype)
-
-                # 2. Unpack ql (lower 4 bits) for this chunk
-                qs_byte_offset = (chunk_idx // 2) * 32
-                qs_bytes = tl.load(qs_start_ptr + qs_byte_offset)
-                use_low_nibbles = chunk_idx % 2 == 0
-                ql = tl.where(use_low_nibbles, qs_bytes & 0x0F, qs_bytes >> 4)
-
-                # 3. Unpack qh (higher 1 bit) for this chunk
-                qh = (qh_bytes_all >> chunk_idx) & 0x01
-
-                # 4. Combine, dequantize, and store
-                q = ql.to(tl.uint8) | (qh.to(tl.uint8) << 4)
-                dequant_32 = final_d * q.to(out_dtype) - final_dm
-
-                output_ptr = output_start_ptr + chunk_idx * 32
-                output_ptr.store(dequant_32)
-
-
-@triton.autotune(
-    configs=_AUTOTUNE_CONFIGS.get("q6_k", _DEFAULT_AUTOTUNE_CONFIGS),
-    key=["n_total_blocks"],
-)
-@triton.jit
-def dequantize_Q6_K_kernel(
-    q_tensor_ptr,
-    out_tensor_ptr,
-    n_total_blocks,
-    OUT_DTYPE: tl.constexpr,
-    N_BLOCKS_PER_PROG: tl.constexpr,
-    TYPE_SIZE: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
-) -> None:
-    out_dtype = OUT_DTYPE.value
-    pid = tl.program_id(axis=0)
-    start_block_idx = pid * N_BLOCKS_PER_PROG
-    offsets_32 = tl.arange(0, 32)
-    mask_16 = offsets_32 < 16
-
-    for i in tl.static_range(N_BLOCKS_PER_PROG):
-        current_block_idx = start_block_idx + i
-        if current_block_idx < n_total_blocks:
-            block_start_ptr = q_tensor_ptr + current_block_idx * TYPE_SIZE
-            output_start_ptr = out_tensor_ptr + current_block_idx * BLOCK_SIZE
-
-            d_ptr = block_start_ptr + 208
-            scales_ptr = block_start_ptr + 192
-            d_super_scale = tl.load(d_ptr.to(tl.pointer_type(tl.float16))).to(out_dtype)
-
-            # Process block in 8 chunks of 32 values
-            for chunk_idx in tl.static_range(8):
-                # 1. Calculate ql source data and unpack
-                ql_byte_offset = (chunk_idx % 2) * 32 + (chunk_idx // 4) * 64
-                ql_ptr = block_start_ptr + ql_byte_offset
-                ql_32_bytes = tl.load(ql_ptr + offsets_32)
-
-                use_low_nibbles = (chunk_idx // 2) % 2 == 0
-                if use_low_nibbles:
-                    ql_vec_32 = (ql_32_bytes & 0x0F).to(tl.int8)
-                else:
-                    ql_vec_32 = (ql_32_bytes >> 4).to(tl.int8)
-
-                # 2. Calculate qh source data and unpack
-                qh_byte_offset = (chunk_idx // 4) * 32
-                qh_ptr = block_start_ptr + 128 + qh_byte_offset
-                qh_32_bytes = tl.load(qh_ptr + offsets_32)
-
-                bit_shift = (chunk_idx % 4) * 2
-                qh_vec_32 = ((qh_32_bytes >> bit_shift) & 0x03).to(tl.int8)
-
-                # 3. Combine and dequantize
-                q_vec_32 = (ql_vec_32 | (qh_vec_32 << 4)) - 32
-
-                # 4. Load and apply correct scales
-                scale_0_ptr = scales_ptr + chunk_idx * 2
-                scale_1_ptr = scales_ptr + chunk_idx * 2 + 1
-                scale_0 = d_super_scale * tl.load(scale_0_ptr).to(tl.int8).to(out_dtype)
-                scale_1 = d_super_scale * tl.load(scale_1_ptr).to(tl.int8).to(out_dtype)
-
-                scales_32 = tl.where(mask_16, scale_0, scale_1)
-                dequant_32 = q_vec_32.to(out_dtype) * scales_32
-
-                # 5. Store result
-                output_ptr = output_start_ptr + chunk_idx * 32
-                tl.store(output_ptr + offsets_32, dequant_32)
+            # 5. Store result
+            output_ptr = out_tensor_ptr + chunk_idx * 32
+            tl.store(output_ptr + offsets_32, dequant_32)
 
 
 ### Legacy quants
 
 
-@triton.autotune(
-    configs=_AUTOTUNE_CONFIGS.get("q4_0", _DEFAULT_AUTOTUNE_CONFIGS),
-    key=["n_total_blocks"],
-)
-@triton.jit
-def dequantize_Q4_0_kernel(
-    q_tensor_ptr,
-    out_tensor_ptr,
-    n_total_blocks,
-    OUT_DTYPE: tl.constexpr,
-    N_BLOCKS_PER_PROG: tl.constexpr,
-    TYPE_SIZE: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
-) -> None:
-    out_dtype = OUT_DTYPE.value
-    pid = tl.program_id(axis=0)
-    start_block_idx = pid * N_BLOCKS_PER_PROG
+@dataclass
+class KernelImpl_Legacy(KernelImpl):
+    @staticmethod
+    @triton.jit
+    def store_output(out_tensor_ptr, dequant_low, dequant_high) -> None:
+        offsets_16 = tl.arange(0, 16)
 
-    # Vector of offsets for the 16 bytes of quantized data
-    offsets_16 = tl.arange(0, 16)
+        out_ptrs_low = out_tensor_ptr + offsets_16
+        out_ptrs_high = out_tensor_ptr + 16 + offsets_16
 
-    for i in tl.static_range(N_BLOCKS_PER_PROG):
-        current_block_idx = start_block_idx + i
-        if current_block_idx < n_total_blocks:
-            # --- Set up pointers for the current block ---
-            block_start_ptr = q_tensor_ptr + current_block_idx * TYPE_SIZE
-            output_start_ptr = out_tensor_ptr + current_block_idx * BLOCK_SIZE
-
-            # 1. Load the float16 scale 'd'. It's the first 2 bytes of the block.
-            d = tl.load(block_start_ptr.to(tl.pointer_type(tl.float16))).to(out_dtype)
-
-            # 2. Load the 16 bytes of quantized data ('qs').
-            qs_ptr = block_start_ptr + 2
-            qs_bytes_16 = tl.load(qs_ptr + offsets_16)
-
-            # 3. Unpack the 16 bytes into 32 4-bit values (nibbles).
-            # The low nibbles form the first 16 values of the block.
-            qs_low = (qs_bytes_16 & 0x0F).to(tl.int8)
-            # The high nibbles form the second 16 values of the block.
-            qs_high = (qs_bytes_16 >> 4).to(tl.int8)
-
-            # 4. Dequantize the values from unsigned 0-15 to signed -8 to 7.
-            q_low = qs_low - 8
-            q_high = qs_high - 8
-
-            # 5. Apply the scale and store the 32 dequantized results.
-            dequant_low = d * q_low.to(out_dtype)
-            dequant_high = d * q_high.to(out_dtype)
-
-            tl.store(output_start_ptr + offsets_16, dequant_low)
-            tl.store(output_start_ptr + 16 + offsets_16, dequant_high)
+        # Store the 32 dequantized results.
+        out_ptrs_low.store(dequant_low)
+        out_ptrs_high.store(dequant_high)
 
 
-@triton.autotune(
-    configs=_AUTOTUNE_CONFIGS.get("q4_1", _DEFAULT_AUTOTUNE_CONFIGS),
-    key=["n_total_blocks"],
-)
-@triton.jit
-def dequantize_Q4_1_kernel(
-    q_tensor_ptr,
-    out_tensor_ptr,
-    n_total_blocks,
-    OUT_DTYPE: tl.constexpr,
-    N_BLOCKS_PER_PROG: tl.constexpr,
-    TYPE_SIZE: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
-) -> None:
-    out_dtype = OUT_DTYPE.value
-    pid = tl.program_id(axis=0)
-    start_block_idx = pid * N_BLOCKS_PER_PROG
+@dataclass
+class KernelImpl_Q4_0(KernelImpl_Legacy):
+    @staticmethod
+    @triton.jit
+    def dequantize_block_kernel(
+        block_start_ptr,
+        out_tensor_ptr,
+        CTX: tl.constexpr,
+        OUT_DTYPE: tl.constexpr,
+    ) -> None:
+        # Vector of offsets for the 16 bytes of quantized data
+        offsets_16 = tl.arange(0, 16)
 
-    # Vector of offsets for the 16 bytes of quantized data
-    offsets_16 = tl.arange(0, 16)
+        # 1. Load the float16 scale 'd'. It's the first 2 bytes of the block.
+        d = tl.load(block_start_ptr.to(tl.pointer_type(tl.float16))).to(OUT_DTYPE)
 
-    for i in tl.static_range(N_BLOCKS_PER_PROG):
-        current_block_idx = start_block_idx + i
-        if current_block_idx < n_total_blocks:
-            # --- Set up pointers for the current block ---
-            block_start_ptr = q_tensor_ptr + current_block_idx * TYPE_SIZE
-            output_start_ptr = out_tensor_ptr + current_block_idx * BLOCK_SIZE
+        # 2. Load the 16 bytes of quantized data ('qs').
+        qs_ptr = block_start_ptr + 2
+        qs_bytes_16 = tl.load(qs_ptr + offsets_16)
 
-            # 1. Load scale 'd' (first 2 bytes) and min 'm' (next 2 bytes).
-            d_ptr = block_start_ptr
-            m_ptr = block_start_ptr + 2
+        # 3. Unpack the 16 bytes into 32 4-bit values (nibbles).
+        # The low nibbles form the first 16 values of the block.
+        qs_low = (qs_bytes_16 & 0x0F).to(tl.int8, bitcast=True)
+        # The high nibbles form the second 16 values of the block.
+        qs_high = (qs_bytes_16 >> 4).to(tl.int8, bitcast=True)
 
-            d = tl.load(d_ptr.to(tl.pointer_type(tl.float16))).to(out_dtype)
-            m = tl.load(m_ptr.to(tl.pointer_type(tl.float16))).to(out_dtype)
+        # 4. Dequantize the values from unsigned 0-15 to signed -8 to 7.
+        q_low = qs_low - 8
+        q_high = qs_high - 8
 
-            # 2. Load the 16 bytes of quantized data ('qs').
-            qs_ptr = block_start_ptr + 4
-            qs_bytes_16 = tl.load(qs_ptr + offsets_16)
+        # 5. Apply the scale and store the 32 dequantized results.
+        dequant_low = d * q_low.to(OUT_DTYPE)
+        dequant_high = d * q_high.to(OUT_DTYPE)
 
-            # 3. Unpack the 16 bytes into 32 4-bit values (0-15).
-            qs_low = (qs_bytes_16 & 0x0F).to(out_dtype)
-            qs_high = (qs_bytes_16 >> 4).to(out_dtype)
-
-            # 4. Dequantize: (d * qs) + m
-            dequant_low = d * qs_low + m
-            dequant_high = d * qs_high + m
-
-            # 5. Store the 32 dequantized results.
-            tl.store(output_start_ptr + offsets_16, dequant_low)
-            tl.store(output_start_ptr + 16 + offsets_16, dequant_high)
+        CTX.store_output(out_tensor_ptr, dequant_low, dequant_high)
 
 
-@triton.autotune(
-    configs=_AUTOTUNE_CONFIGS.get("q5_0", _DEFAULT_AUTOTUNE_CONFIGS),
-    key=["n_total_blocks"],
-)
-@triton.jit
-def dequantize_Q5_0_kernel(
-    q_tensor_ptr,
-    out_tensor_ptr,
-    n_total_blocks,
-    OUT_DTYPE: tl.constexpr,
-    N_BLOCKS_PER_PROG: tl.constexpr,
-    TYPE_SIZE: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
-) -> None:
-    out_dtype = OUT_DTYPE.value
-    pid = tl.program_id(axis=0)
-    start_block_idx = pid * N_BLOCKS_PER_PROG
+@dataclass
+class KernelImpl_Q4_1(KernelImpl_Legacy):
+    @staticmethod
+    @triton.jit
+    def dequantize_block_kernel(
+        block_start_ptr,
+        out_tensor_ptr,
+        CTX: tl.constexpr,
+        OUT_DTYPE: tl.constexpr,
+    ) -> None:
+        # Vector of offsets for the 16 bytes of quantized data
+        offsets_16 = tl.arange(0, 16)
 
-    # Vector of offsets for 16-element vectors
-    offsets_16 = tl.arange(0, 16)
+        # 1. Load scale 'd' (first 2 bytes) and min 'm' (next 2 bytes).
+        d_ptr = block_start_ptr
+        m_ptr = block_start_ptr + 2
 
-    for i in tl.static_range(N_BLOCKS_PER_PROG):
-        current_block_idx = start_block_idx + i
-        if current_block_idx < n_total_blocks:
-            # --- Set up pointers for the current block ---
-            block_start_ptr = q_tensor_ptr + current_block_idx * TYPE_SIZE
-            output_start_ptr = out_tensor_ptr + current_block_idx * BLOCK_SIZE
+        d = tl.load(d_ptr.to(tl.pointer_type(tl.float16))).to(OUT_DTYPE)
+        m = tl.load(m_ptr.to(tl.pointer_type(tl.float16))).to(OUT_DTYPE)
 
-            # Data layout: 2 bytes 'd', 4 bytes 'qh', 16 bytes 'qs'
-            d_ptr = block_start_ptr
-            qh_ptr = block_start_ptr + 2
-            qs_ptr = block_start_ptr + 6
+        # 2. Load the 16 bytes of quantized data ('qs').
+        qs_ptr = block_start_ptr + 4
+        qs_bytes_16 = tl.load(qs_ptr + offsets_16)
 
-            # 1. Load the scale 'd' and the high-bit mask 'qh'.
-            d = tl.load(d_ptr.to(tl.pointer_type(tl.float16))).to(out_dtype)
+        # 3. Unpack the 16 bytes into 32 4-bit values (0-15).
+        qs_low = (qs_bytes_16 & 0x0F).to(OUT_DTYPE)
+        qs_high = (qs_bytes_16 >> 4).to(OUT_DTYPE)
 
-            # Perform an unaligned load for the 4 bytes of qh.
-            b0 = tl.load(qh_ptr + 0).to(tl.uint32)
-            b1 = tl.load(qh_ptr + 1).to(tl.uint32) << 8
-            b2 = tl.load(qh_ptr + 2).to(tl.uint32) << 16
-            b3 = tl.load(qh_ptr + 3).to(tl.uint32) << 24
-            qh_word = b0 | b1 | b2 | b3
+        # 4. Dequantize: (d * qs) + m
+        dequant_low = d * qs_low + m
+        dequant_high = d * qs_high + m
 
-            # 2. Load the 16 bytes of low-bits 'qs'.
-            qs_bytes_16 = tl.load(qs_ptr + offsets_16)
-
-            # --- Process the first 16 values ---
-            ql_low = (qs_bytes_16 & 0x0F).to(tl.uint8)
-            qh_low = ((qh_word >> offsets_16) & 1).to(tl.uint8)
-            q_low = (ql_low | (qh_low << 4)).to(tl.int8) - 16
-            dequant_low = d * q_low.to(out_dtype)
-
-            # --- Process the second 16 values ---
-            ql_high = (qs_bytes_16 >> 4).to(tl.uint8)
-            qh_high = ((qh_word >> (offsets_16 + 16)) & 1).to(tl.uint8)
-            q_high = (ql_high | (qh_high << 4)).to(tl.int8) - 16
-            dequant_high = d * q_high.to(out_dtype)
-
-            # 4. Store the 32 dequantized results.
-            tl.store(output_start_ptr + offsets_16, dequant_low)
-            tl.store(output_start_ptr + 16 + offsets_16, dequant_high)
+        CTX.store_output(out_tensor_ptr, dequant_low, dequant_high)
 
 
-@triton.autotune(
-    configs=_AUTOTUNE_CONFIGS.get("q5_1", _DEFAULT_AUTOTUNE_CONFIGS),
-    key=["n_total_blocks"],
-)
-@triton.jit
-def dequantize_Q5_1_kernel(
-    q_tensor_ptr,
-    out_tensor_ptr,
-    n_total_blocks,
-    OUT_DTYPE: tl.constexpr,
-    N_BLOCKS_PER_PROG: tl.constexpr,
-    TYPE_SIZE: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
-) -> None:
-    out_dtype = OUT_DTYPE.value
-    pid = tl.program_id(axis=0)
-    start_block_idx = pid * N_BLOCKS_PER_PROG
+@dataclass
+class KernelImpl_Q5_0(KernelImpl_Legacy):
+    @staticmethod
+    @triton.jit
+    def dequantize_block_kernel(
+        block_start_ptr,
+        out_tensor_ptr,
+        CTX: tl.constexpr,
+        OUT_DTYPE: tl.constexpr,
+    ) -> None:
+        offsets_16 = tl.arange(0, 16)
+        offsets_4 = tl.arange(0, 4)
 
-    # Vector of offsets for 16-element vectors
-    offsets_16 = tl.arange(0, 16)
+        d_ptr = block_start_ptr
+        qh_ptr = block_start_ptr + 2
+        qs_ptr = block_start_ptr + 6
 
-    for i in tl.static_range(N_BLOCKS_PER_PROG):
-        current_block_idx = start_block_idx + i
-        if current_block_idx < n_total_blocks:
-            # --- Set up pointers for the current block ---
-            block_start_ptr = q_tensor_ptr + current_block_idx * TYPE_SIZE
-            output_start_ptr = out_tensor_ptr + current_block_idx * BLOCK_SIZE
+        d = tl.load(d_ptr.to(tl.pointer_type(tl.float16))).to(OUT_DTYPE)
+        qh_word = (tl.load(qh_ptr + offsets_4).to(tl.uint32) << (offsets_4 << 3)).sum()
+        qs_bytes_16 = tl.load(qs_ptr + offsets_16)
 
-            # Data layout: 2 bytes 'd', 2 bytes 'm', 4 bytes 'qh', 16 bytes 'qs'
-            d_ptr = block_start_ptr
-            m_ptr = block_start_ptr + 2
-            qh_ptr = block_start_ptr + 4
-            qs_ptr = block_start_ptr + 8
+        ql_low = qs_bytes_16 & 0x0F
+        qh_low = (qh_word >> offsets_16) & 1
+        q_low = (ql_low | (qh_low << 4)).to(tl.int8, bitcast=True) - 16
+        dequant_low = d * q_low.to(OUT_DTYPE)  # Shape: [16]
 
-            # 1. Load the scales 'd', 'm' and the high-bit mask 'qh'.
-            d = tl.load(d_ptr.to(tl.pointer_type(tl.float16))).to(out_dtype)
-            m = tl.load(m_ptr.to(tl.pointer_type(tl.float16))).to(out_dtype)
-            # This is a safe aligned load because TYPE_SIZE (24) and qh offset (4) are multiples of 4.
-            qh_word = tl.load(qh_ptr.to(tl.pointer_type(tl.uint32)))
+        ql_high = qs_bytes_16 >> 4
+        qh_high = (qh_word >> (offsets_16 + 16)) & 1
+        q_high = (ql_high | (qh_high << 4)).to(tl.int8, bitcast=True) - 16
+        dequant_high = d * q_high.to(OUT_DTYPE)  # Shape: [16]
 
-            # 2. Load the 16 bytes of low-bits 'qs'.
-            qs_bytes_16 = tl.load(qs_ptr + offsets_16)
+        CTX.store_output(out_tensor_ptr, dequant_low, dequant_high)
 
-            # --- Process the first 16 values ---
-            ql_low = (qs_bytes_16 & 0x0F).to(tl.uint8)
-            qh_low = ((qh_word >> offsets_16) & 1).to(tl.uint8)
-            q_low = (ql_low | (qh_low << 4)).to(out_dtype)
-            dequant_low = d * q_low + m
 
-            # --- Process the second 16 values ---
-            ql_high = (qs_bytes_16 >> 4).to(tl.uint8)
-            qh_high = ((qh_word >> (offsets_16 + 16)) & 1).to(tl.uint8)
-            q_high = (ql_high | (qh_high << 4)).to(out_dtype)
-            dequant_high = d * q_high + m
+@dataclass
+class KernelImpl_Q5_1(KernelImpl_Legacy):
+    @staticmethod
+    @triton.jit
+    def dequantize_block_kernel(
+        block_start_ptr,
+        out_tensor_ptr,
+        CTX: tl.constexpr,
+        OUT_DTYPE: tl.constexpr,
+    ) -> None:
+        offsets_16 = tl.arange(0, 16)
 
-            # 4. Store the 32 dequantized results.
-            tl.store(output_start_ptr + offsets_16, dequant_low)
-            tl.store(output_start_ptr + 16 + offsets_16, dequant_high)
+        # Data layout: 2 bytes 'd', 2 bytes 'm', 4 bytes 'qh', 16 bytes 'qs'
+        d_ptr = block_start_ptr
+        m_ptr = block_start_ptr + 2
+        qh_ptr = block_start_ptr + 4
+        qs_ptr = block_start_ptr + 8
+
+        # 1. Load the scales 'd', 'm' and the high-bit mask 'qh'.
+        d = tl.load(d_ptr.to(tl.pointer_type(tl.float16))).to(OUT_DTYPE)
+        m = tl.load(m_ptr.to(tl.pointer_type(tl.float16))).to(OUT_DTYPE)
+        # This is a safe aligned load because TYPE_SIZE (24) and qh offset (4) are multiples of 4.
+        qh_word = tl.load(qh_ptr.to(tl.pointer_type(tl.uint32)))
+
+        # 2. Load the 16 bytes of low-bits 'qs'.
+        qs_bytes_16 = tl.load(qs_ptr + offsets_16)
+
+        # --- Process the first 16 values ---
+        ql_low = qs_bytes_16 & 0x0F
+        qh_low = (qh_word >> offsets_16) & 1
+        q_low = (ql_low | (qh_low << 4)).to(OUT_DTYPE)
+        dequant_low = d * q_low + m
+
+        # --- Process the second 16 values ---
+        ql_high = qs_bytes_16 >> 4
+        qh_high = (qh_word >> (offsets_16 + 16)) & 1
+        q_high = (ql_high | (qh_high << 4)).to(OUT_DTYPE)
+        dequant_high = d * q_high + m
+
+        CTX.store_output(out_tensor_ptr, dequant_low, dequant_high)
 
 
 dequantize_functions: dict[GGMLQuantizationType, KernelDefinition] = {
-    GQT.Q4_0: KernelDefinition.build(
-        qtype=GQT.Q4_0,
-        kernel=dequantize_Q4_0_kernel,
-    ),
-    GQT.Q4_1: KernelDefinition.build(
-        qtype=GQT.Q4_1,
-        kernel=dequantize_Q4_1_kernel,
-    ),
-    GQT.Q5_0: KernelDefinition.build(
-        qtype=GQT.Q5_0,
-        kernel=dequantize_Q5_0_kernel,
-    ),
-    GQT.Q5_1: KernelDefinition.build(
-        qtype=GQT.Q5_1,
-        kernel=dequantize_Q5_1_kernel,
-    ),
-    GQT.Q2_K: KernelDefinition.build(
-        qtype=GQT.Q2_K,
-        kernel=dequantize_Q2_K_kernel,
-    ),
-    GQT.Q3_K: KernelDefinition.build(
-        qtype=GQT.Q3_K,
-        kernel=dequantize_Q3_K_kernel,
-    ),
-    GQT.Q4_K: KernelDefinition.build(
-        qtype=GQT.Q4_K,
-        kernel=dequantize_Q4_K_kernel,
-        K_SCALE_SIZE=K_SCALE_SIZE,
-        get_scales_min=dequantize_Q4_K_Q5_K_get_scales_min,
-    ),
-    GQT.Q5_K: KernelDefinition.build(
-        qtype=GQT.Q5_K,
-        kernel=dequantize_Q5_K_kernel,
-        K_SCALE_SIZE=K_SCALE_SIZE,
-        get_scales_min=dequantize_Q4_K_Q5_K_get_scales_min,
-    ),
-    GQT.Q6_K: KernelDefinition.build(
-        qtype=GQT.Q6_K,
-        kernel=dequantize_Q6_K_kernel,
-    ),
+    GQT.Q4_0: KernelDefinition.build(GQT.Q4_0, KernelImpl_Q4_0),
+    GQT.Q4_1: KernelDefinition.build(GQT.Q4_1, KernelImpl_Q4_1),
+    GQT.Q5_0: KernelDefinition.build(GQT.Q5_0, KernelImpl_Q5_0),
+    GQT.Q5_1: KernelDefinition.build(GQT.Q5_1, KernelImpl_Q5_1),
+    GQT.Q2_K: KernelDefinition.build(GQT.Q2_K, KernelImpl_Q2_K),
+    GQT.Q3_K: KernelDefinition.build(GQT.Q3_K, KernelImpl_Q3_K),
+    GQT.Q4_K: KernelDefinition.build(GQT.Q4_K, KernelImpl_Q4_K),
+    GQT.Q5_K: KernelDefinition.build(GQT.Q5_K, KernelImpl_Q5_K),
+    GQT.Q6_K: KernelDefinition.build(GQT.Q6_K, KernelImpl_Q6_K),
 }
 
 __all__ = ("dequantize_functions",)

--- a/dequant_triton.py
+++ b/dequant_triton.py
@@ -71,7 +71,6 @@ def dequantize_q8_0_kernel(
 
             # Dequantize
             dequantized_weights = q_weights.to(OUT_DTYPE) * scale
-            # dequantized_weights = q_weights.to(tl.float32) * scale
 
             # Store the result
             output_start_ptr = out_tensor_ptr + current_block_idx * GGUF_BLOCK_SIZE
@@ -136,7 +135,7 @@ def dequantize_q4_k_kernel(
     out_tensor_ptr,
     n_total_blocks,
     QK_K: tl.constexpr,
-    Q4_K_TYPE_SIZE: tl.constexpr,
+    TYPE_SIZE: tl.constexpr,
     K_SCALE_SIZE: tl.constexpr,
     N_BLOCKS_PER_PROG: tl.constexpr,
     OUT_DTYPE: tl.constexpr,
@@ -150,7 +149,7 @@ def dequantize_q4_k_kernel(
     for i in range(N_BLOCKS_PER_PROG):
         current_block_idx = start_block_idx + i
         if current_block_idx < n_total_blocks:
-            block_start_ptr = q_tensor_ptr + current_block_idx * Q4_K_TYPE_SIZE
+            block_start_ptr = q_tensor_ptr + current_block_idx * TYPE_SIZE
             output_start_ptr = out_tensor_ptr + current_block_idx * QK_K
 
             d = tl.load(block_start_ptr.to(tl.pointer_type(tl.float16))).to(OUT_DTYPE)
@@ -228,13 +227,11 @@ def dequantize_blocks_Q4_K_triton(
     type_size: int,
     dtype=None,
 ) -> torch.Tensor:
-    Q4_K_TYPE_SIZE = 144
-
     assert blocks.dtype == torch.uint8 and blocks.is_cuda and blocks.is_contiguous()
 
     n_elements = blocks.numel()
-    assert n_elements % Q4_K_TYPE_SIZE == 0
-    n_total_blocks = n_elements // Q4_K_TYPE_SIZE
+    assert n_elements % type_size == 0
+    n_total_blocks = n_elements // type_size
 
     dtype = dtype or torch.float32
     triton_dtype = TORCH_TO_TRITON_DTYPE_MAP.get(dtype)
@@ -253,7 +250,7 @@ def dequantize_blocks_Q4_K_triton(
         out_tensor,
         n_total_blocks,
         QK_K=QK_K,
-        Q4_K_TYPE_SIZE=Q4_K_TYPE_SIZE,
+        TYPE_SIZE=type_size,
         K_SCALE_SIZE=K_SCALE_SIZE,
         OUT_DTYPE=triton_dtype,
     )
@@ -261,9 +258,127 @@ def dequantize_blocks_Q4_K_triton(
     return out_tensor.reshape(n_total_blocks, -1)
 
 
+@triton.autotune(
+    configs=[
+        triton.Config({"N_BLOCKS_PER_PROG": 1}, num_warps=4),
+        triton.Config({"N_BLOCKS_PER_PROG": 2}, num_warps=4),
+        triton.Config({"N_BLOCKS_PER_PROG": 4}, num_warps=4),
+        triton.Config({"N_BLOCKS_PER_PROG": 1}, num_warps=8),
+        triton.Config({"N_BLOCKS_PER_PROG": 2}, num_warps=8),
+        triton.Config({"N_BLOCKS_PER_PROG": 4}, num_warps=8),
+    ],
+    key=["n_total_blocks"],
+)
+@triton.jit
+def dequantize_q6_k_kernel(
+    q_tensor_ptr,
+    out_tensor_ptr,
+    n_total_blocks,
+    QK_K: tl.constexpr,
+    TYPE_SIZE: tl.constexpr,
+    OUT_DTYPE: tl.constexpr,
+    N_BLOCKS_PER_PROG: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    start_block_idx = pid * N_BLOCKS_PER_PROG
+    offsets_32 = tl.arange(0, 32)
+    mask_16 = offsets_32 < 16
+
+    for i in range(N_BLOCKS_PER_PROG):
+        current_block_idx = start_block_idx + i
+        if current_block_idx < n_total_blocks:
+            block_start_ptr = q_tensor_ptr + current_block_idx * TYPE_SIZE
+            output_start_ptr = out_tensor_ptr + current_block_idx * QK_K
+
+            d_ptr = block_start_ptr + 208
+            scales_ptr = block_start_ptr + 192
+            d_super_scale = tl.load(d_ptr.to(tl.pointer_type(tl.float16))).to(
+                tl.float32
+            )
+
+            # Process block in 8 chunks of 32 values
+            for chunk_idx in range(8):
+                # 1. Calculate ql source data and unpack
+                ql_byte_offset = (chunk_idx % 2) * 32 + (chunk_idx // 4) * 64
+                ql_ptr = block_start_ptr + ql_byte_offset
+                ql_32_bytes = tl.load(ql_ptr + offsets_32)
+
+                use_low_nibbles = (chunk_idx // 2) % 2 == 0
+                if use_low_nibbles:
+                    ql_vec_32 = (ql_32_bytes & 0x0F).to(tl.int8)
+                else:
+                    ql_vec_32 = (ql_32_bytes >> 4).to(tl.int8)
+
+                # 2. Calculate qh source data and unpack
+                qh_byte_offset = (chunk_idx // 4) * 32
+                qh_ptr = block_start_ptr + 128 + qh_byte_offset
+                qh_32_bytes = tl.load(qh_ptr + offsets_32)
+
+                bit_shift = (chunk_idx % 4) * 2
+                qh_vec_32 = ((qh_32_bytes >> bit_shift) & 0x03).to(tl.int8)
+
+                # 3. Combine and dequantize
+                q_vec_32 = (ql_vec_32 | (qh_vec_32 << 4)) - 32
+
+                # 4. Load and apply correct scales
+                scale_0_ptr = scales_ptr + chunk_idx * 2
+                scale_1_ptr = scales_ptr + chunk_idx * 2 + 1
+                scale_0 = d_super_scale * tl.load(scale_0_ptr).to(tl.int8).to(
+                    tl.float32
+                )
+                scale_1 = d_super_scale * tl.load(scale_1_ptr).to(tl.int8).to(
+                    tl.float32
+                )
+
+                scales_32 = tl.where(mask_16, scale_0, scale_1)
+                dequant_32 = q_vec_32.to(OUT_DTYPE) * scales_32
+
+                # 5. Store result
+                output_ptr = output_start_ptr + chunk_idx * 32
+                tl.store(output_ptr + offsets_32, dequant_32)
+
+
+def dequantize_blocks_Q6_K_triton(
+    blocks: torch.Tensor,
+    block_size: int,
+    type_size: int,
+    dtype=None,
+) -> torch.Tensor:
+    assert blocks.dtype == torch.uint8 and blocks.is_cuda and blocks.is_contiguous()
+
+    n_elements = blocks.numel()
+    assert n_elements % type_size == 0
+    n_total_blocks = n_elements // type_size
+
+    dtype = dtype or torch.float32
+    triton_dtype = TORCH_TO_TRITON_DTYPE_MAP.get(dtype)
+    if triton_dtype is None:
+        raise TypeError(f"Unsupported output dtype {dtype}")
+
+    out_tensor = torch.empty(
+        (n_total_blocks * QK_K,), dtype=dtype, device=blocks.device
+    )
+
+    def grid(meta):
+        return (triton.cdiv(n_total_blocks, meta["N_BLOCKS_PER_PROG"]),)
+
+    dequantize_q6_k_kernel[grid](
+        blocks,
+        out_tensor,
+        n_total_blocks,
+        QK_K=QK_K,
+        TYPE_SIZE=type_size,
+        OUT_DTYPE=triton_dtype,
+    )
+
+    return out_tensor.reshape(n_total_blocks, -1)
+
+
 dequantize_functions = {
-    gguf.GGMLQuantizationType.Q8_0: dequantize_blocks_Q8_0_triton,
+    # Q8_0 simply seems than the PyTorch implementation.
+    # gguf.GGMLQuantizationType.Q8_0: dequantize_blocks_Q8_0_triton,
     gguf.GGMLQuantizationType.Q4_K: dequantize_blocks_Q4_K_triton,
+    gguf.GGMLQuantizationType.Q6_K: dequantize_blocks_Q6_K_triton,
 }
 
 __all__ = ("dequantize_functions",)

--- a/dequant_triton.py
+++ b/dequant_triton.py
@@ -497,7 +497,7 @@ dequantize_functions = {
     # Q8_0 simply seems than the PyTorch implementation.
     # gguf.GGMLQuantizationType.Q8_0: dequantize_blocks_Q8_0_triton,
     gguf.GGMLQuantizationType.Q4_K: dequantize_blocks_Q4_K_triton,
-    # gguf.GGMLQuantizationType.Q5_K: dequantize_blocks_Q5_K_triton,
+    gguf.GGMLQuantizationType.Q5_K: dequantize_blocks_Q5_K_triton,
     gguf.GGMLQuantizationType.Q6_K: dequantize_blocks_Q6_K_triton,
 }
 

--- a/dequant_triton.py
+++ b/dequant_triton.py
@@ -1,0 +1,269 @@
+import torch
+
+import triton
+import triton.language as tl
+
+import gguf
+
+TORCH_TO_TRITON_DTYPE_MAP = {
+    torch.float32: tl.float32,
+    torch.float16: tl.float16,
+    torch.bfloat16: tl.bfloat16,
+}
+
+# K Quants #
+QK_K = 256
+K_SCALE_SIZE = 12
+
+
+@triton.autotune(
+    configs=[
+        # Test different numbers of GGUF blocks per program instance
+        triton.Config({"N_BLOCKS_PER_PROG": 1}, num_warps=4),
+        triton.Config({"N_BLOCKS_PER_PROG": 2}, num_warps=4),
+        triton.Config({"N_BLOCKS_PER_PROG": 4}, num_warps=4),
+        triton.Config({"N_BLOCKS_PER_PROG": 8}, num_warps=4),
+        triton.Config({"N_BLOCKS_PER_PROG": 1}, num_warps=8),
+        triton.Config({"N_BLOCKS_PER_PROG": 2}, num_warps=8),
+        triton.Config({"N_BLOCKS_PER_PROG": 4}, num_warps=8),
+        triton.Config({"N_BLOCKS_PER_PROG": 8}, num_warps=8),
+    ],
+    key=["n_total_blocks"],  # Tune based on the total number of blocks
+)
+@triton.jit
+def dequantize_q8_0_kernel(
+    q_tensor_ptr,
+    out_tensor_ptr,
+    n_total_blocks,
+    GGUF_BLOCK_SIZE: tl.constexpr,
+    GGUF_TYPE_SIZE: tl.constexpr,
+    N_BLOCKS_PER_PROG: tl.constexpr,  # How many blocks each program handles
+    OUT_DTYPE: tl.constexpr,
+):
+    # Each program is responsible for a chunk of N_BLOCKS_PER_PROG blocks
+    pid = tl.program_id(axis=0)
+
+    # Starting GGUF block index for this program
+    start_block_idx = pid * N_BLOCKS_PER_PROG
+
+    # Create offsets for the weights within a GGUF block (0, 1, ..., 31)
+    weight_indices = tl.arange(0, GGUF_BLOCK_SIZE)
+
+    # Loop over the N blocks assigned to this program
+    for i in range(N_BLOCKS_PER_PROG):
+        current_block_idx = start_block_idx + i
+
+        # Boundary check to avoid processing padding blocks
+        if current_block_idx < n_total_blocks:
+            # Pointer to the start of the current GGUF block in the input tensor
+            block_start_ptr = q_tensor_ptr + current_block_idx * GGUF_TYPE_SIZE
+
+            # Load scale (d)
+            uint16_ptr = block_start_ptr.to(tl.pointer_type(tl.uint16))
+            uint16_val = tl.load(uint16_ptr)
+            scale_fp16 = tl.cast(uint16_val, tl.float16, bitcast=True)
+            scale = scale_fp16.to(tl.float32)
+
+            # Load weights (x)
+            q_weights_ptr = block_start_ptr + 2
+            uint8_weights = tl.load(q_weights_ptr + weight_indices)
+            q_weights = uint8_weights.to(tl.int8)
+
+            # Dequantize
+            dequantized_weights = q_weights.to(OUT_DTYPE) * scale
+            # dequantized_weights = q_weights.to(tl.float32) * scale
+
+            # Store the result
+            output_start_ptr = out_tensor_ptr + current_block_idx * GGUF_BLOCK_SIZE
+            tl.store(output_start_ptr + weight_indices, dequantized_weights)
+
+
+def dequantize_blocks_Q8_0_triton(
+    blocks: torch.Tensor,
+    block_size: int,
+    type_size: int,
+    dtype=None,
+) -> torch.Tensor:
+    GGUF_BLOCK_SIZE = 32
+    GGUF_TYPE_SIZE = 34
+
+    assert blocks.dtype == torch.uint8 and blocks.is_cuda and blocks.is_contiguous()
+
+    n_elements = blocks.numel()
+    assert n_elements % GGUF_TYPE_SIZE == 0
+    n_total_blocks = n_elements // GGUF_TYPE_SIZE
+
+    dtype = dtype or torch.float32
+    triton_dtype = TORCH_TO_TRITON_DTYPE_MAP.get(dtype)
+    if triton_dtype is None:
+        raise TypeError(f"Unsupported output dtype {dtype}")
+
+    out_tensor = torch.empty(
+        (n_total_blocks * GGUF_BLOCK_SIZE,),
+        dtype=dtype,
+        device=blocks.device,
+    )
+
+    def grid(meta):
+        return (triton.cdiv(n_total_blocks, meta["N_BLOCKS_PER_PROG"]),)
+
+    dequantize_q8_0_kernel[grid](
+        blocks,
+        out_tensor,
+        n_total_blocks,
+        GGUF_BLOCK_SIZE=GGUF_BLOCK_SIZE,
+        GGUF_TYPE_SIZE=GGUF_TYPE_SIZE,
+        OUT_DTYPE=triton_dtype,
+    )
+
+    return out_tensor.reshape(n_total_blocks, -1)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"N_BLOCKS_PER_PROG": 1}, num_warps=4),
+        triton.Config({"N_BLOCKS_PER_PROG": 2}, num_warps=4),
+        triton.Config({"N_BLOCKS_PER_PROG": 4}, num_warps=4),
+        triton.Config({"N_BLOCKS_PER_PROG": 1}, num_warps=8),
+        triton.Config({"N_BLOCKS_PER_PROG": 2}, num_warps=8),
+        triton.Config({"N_BLOCKS_PER_PROG": 4}, num_warps=8),
+    ],
+    key=["n_total_blocks"],
+)
+@triton.jit
+def dequantize_q4_k_kernel(
+    q_tensor_ptr,
+    out_tensor_ptr,
+    n_total_blocks,
+    QK_K: tl.constexpr,
+    Q4_K_TYPE_SIZE: tl.constexpr,
+    K_SCALE_SIZE: tl.constexpr,
+    N_BLOCKS_PER_PROG: tl.constexpr,
+    OUT_DTYPE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    start_block_idx = pid * N_BLOCKS_PER_PROG
+
+    qs_chunk_offsets = tl.arange(0, 32)
+    store_offsets = tl.arange(0, 32)
+
+    for i in range(N_BLOCKS_PER_PROG):
+        current_block_idx = start_block_idx + i
+        if current_block_idx < n_total_blocks:
+            block_start_ptr = q_tensor_ptr + current_block_idx * Q4_K_TYPE_SIZE
+            output_start_ptr = out_tensor_ptr + current_block_idx * QK_K
+
+            d = tl.load(block_start_ptr.to(tl.pointer_type(tl.float16))).to(OUT_DTYPE)
+            dmin = tl.load((block_start_ptr + 2).to(tl.pointer_type(tl.float16))).to(
+                OUT_DTYPE
+            )
+
+            scales_ptr_u32 = (block_start_ptr + 4).to(tl.pointer_type(tl.uint32))
+            d_sc_word = tl.load(scales_ptr_u32 + 0)
+            m_word = tl.load(scales_ptr_u32 + 1)
+            m_sc_word = tl.load(scales_ptr_u32 + 2)
+
+            qs_start_ptr = block_start_ptr + 4 + K_SCALE_SIZE
+
+            # Process in 4 chunks of 64 values
+            for k_chunk in range(4):
+                # Scale indices for low (a) and high (b) nibbles
+                k_idx_a = 2 * k_chunk
+                k_idx_b = 2 * k_chunk + 1
+
+                # --- Calculate Scale A (for low nibbles) ---
+                if k_idx_a < 4:
+                    d_sc_byte_a = (d_sc_word >> (k_idx_a * 8)) & 0xFF
+                    m_byte_a = (m_word >> (k_idx_a * 8)) & 0xFF
+                    sc_a = d_sc_byte_a & 0x3F
+                    m_a = m_byte_a & 0x3F
+                else:
+                    k_prime_a = k_idx_a - 4
+                    d_sc_byte_a = (d_sc_word >> (k_prime_a * 8)) & 0xFF
+                    m_byte_a = (m_word >> (k_prime_a * 8)) & 0xFF
+                    m_sc_byte_a = (m_sc_word >> (k_prime_a * 8)) & 0xFF
+                    sc_a = (m_sc_byte_a & 0x0F) | ((d_sc_byte_a >> 2) & 0x30)
+                    m_a = (m_sc_byte_a >> 4) | ((m_byte_a >> 2) & 0x30)
+
+                # --- Calculate Scale B (for high nibbles) ---
+                if k_idx_b < 4:
+                    d_sc_byte_b = (d_sc_word >> (k_idx_b * 8)) & 0xFF
+                    m_byte_b = (m_word >> (k_idx_b * 8)) & 0xFF
+                    sc_b = d_sc_byte_b & 0x3F
+                    m_b = m_byte_b & 0x3F
+                else:
+                    k_prime_b = k_idx_b - 4
+                    d_sc_byte_b = (d_sc_word >> (k_prime_b * 8)) & 0xFF
+                    m_byte_b = (m_word >> (k_prime_b * 8)) & 0xFF
+                    m_sc_byte_b = (m_sc_word >> (k_prime_b * 8)) & 0xFF
+                    sc_b = (m_sc_byte_b & 0x0F) | ((d_sc_byte_b >> 2) & 0x30)
+                    m_b = (m_sc_byte_b >> 4) | ((m_byte_b >> 2) & 0x30)
+
+                current_d_a = d * sc_a.to(OUT_DTYPE)
+                current_dm_a = dmin * m_a.to(OUT_DTYPE)
+                current_d_b = d * sc_b.to(OUT_DTYPE)
+                current_dm_b = dmin * m_b.to(OUT_DTYPE)
+
+                # Load 32 bytes of quantized data
+                chunk_qs_ptr = qs_start_ptr + k_chunk * 32
+                qs_bytes_chunk = tl.load(chunk_qs_ptr + qs_chunk_offsets)
+
+                qs_low = (qs_bytes_chunk & 0x0F).to(OUT_DTYPE)
+                qs_high = (qs_bytes_chunk >> 4).to(OUT_DTYPE)
+
+                dequant_low = current_d_a * qs_low - current_dm_a
+                dequant_high = current_d_b * qs_high - current_dm_b
+
+                # Store results contiguously
+                output_chunk_ptr = output_start_ptr + k_chunk * 64
+                tl.store(output_chunk_ptr + store_offsets, dequant_low.to(OUT_DTYPE))
+                tl.store(
+                    output_chunk_ptr + 32 + store_offsets, dequant_high.to(OUT_DTYPE)
+                )
+
+
+def dequantize_blocks_Q4_K_triton(
+    blocks: torch.Tensor,
+    block_size: int,
+    type_size: int,
+    dtype=None,
+) -> torch.Tensor:
+    Q4_K_TYPE_SIZE = 144
+
+    assert blocks.dtype == torch.uint8 and blocks.is_cuda and blocks.is_contiguous()
+
+    n_elements = blocks.numel()
+    assert n_elements % Q4_K_TYPE_SIZE == 0
+    n_total_blocks = n_elements // Q4_K_TYPE_SIZE
+
+    dtype = dtype or torch.float32
+    triton_dtype = TORCH_TO_TRITON_DTYPE_MAP.get(dtype)
+    if triton_dtype is None:
+        raise TypeError(f"Unsupported output dtype {dtype}")
+
+    out_tensor = torch.empty(
+        (n_total_blocks * QK_K,), dtype=dtype, device=blocks.device
+    )
+
+    def grid(meta):
+        return (triton.cdiv(n_total_blocks, meta["N_BLOCKS_PER_PROG"]),)
+
+    dequantize_q4_k_kernel[grid](
+        blocks,
+        out_tensor,
+        n_total_blocks,
+        QK_K=QK_K,
+        Q4_K_TYPE_SIZE=Q4_K_TYPE_SIZE,
+        K_SCALE_SIZE=K_SCALE_SIZE,
+        OUT_DTYPE=triton_dtype,
+    )
+
+    return out_tensor.reshape(n_total_blocks, -1)
+
+
+dequantize_functions = {
+    gguf.GGMLQuantizationType.Q8_0: dequantize_blocks_Q8_0_triton,
+    gguf.GGMLQuantizationType.Q4_K: dequantize_blocks_Q4_K_triton,
+}
+
+__all__ = ("dequantize_functions",)

--- a/dequant_triton.py
+++ b/dequant_triton.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field as dcfield
+from dataclasses import dataclass
+from dataclasses import field as dcfield
 from typing import Any, TypeVar
 
 import torch
@@ -9,10 +10,15 @@ import triton.language as tl
 from gguf import GGML_QUANT_SIZES, GGMLQuantizationType
 
 C = TypeVar("C")
+
+
 def passthroughdecorator(c: C) -> C:
     return c
 
-nocompiledecorator = getattr(getattr(torch, "compiler", None), "disable", None) or passthroughdecorator
+
+nocompiledecorator = (
+    getattr(getattr(torch, "compiler", None), "disable", None) or passthroughdecorator
+)
 
 TRITON_MAJOR, TRITON_MINOR = (
     int(part) for part in triton.__version__.split(".", 3)[:2]
@@ -35,7 +41,6 @@ else:
     )
     maybestaticmethod = staticmethod
 
-GQT = GGMLQuantizationType
 
 K_SCALE_SIZE = 12
 
@@ -57,20 +62,55 @@ _DEFAULT_AUTOTUNE_CONFIGS: list[triton.Config] = [
     triton.Config({"N_BLOCKS_PER_PROG": 4}, num_warps=8),
 ]
 
-_AUTOTUNE_CONFIGS: dict[str, list[triton.Config]] = {}
+_QUANT_AUTOTUNE_CONFIGS: dict[str, list[triton.Config]] = {}
+
+_DEFAULT_VECTORIZED_AUTOTUNE_CONFIGS: list[triton.Config] = [
+    triton.Config({"BLOCK_N": 16}, num_warps=2),
+    triton.Config({"BLOCK_N": 32}, num_warps=2),
+    triton.Config({"BLOCK_N": 64}, num_warps=4),
+    triton.Config({"BLOCK_N": 128}, num_warps=4),
+    triton.Config({"BLOCK_N": 256}, num_warps=8),
+]
+
+_VECTORIZED_QUANT_AUTOTUNE_CONFIGS: dict[str, list[triton.Config]] = {}
 
 
 @dataclass(frozen=True)
 class KernelImpl:
     type_size: tl.constexpr
     block_size: tl.constexpr
+    # Vectorized kernel related parameters.
+    vectorized: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(False))
+    chunk_size: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(32))
+    num_chunks: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(1))
 
-    def get_autotuner(self, **kwargs: dict) -> triton.runtime.Autotuner:
-        return triton.autotune(**kwargs)(self.dequantize_kernel)
+    @property
+    def have_vectorized(self) -> bool:
+        return bool(getattr(self.vectorized, "value", self.vectorized))
+
+    def get_autotuner(
+        self,
+        *,
+        use_vectorized: bool = True,
+        **kwargs: Any,
+    ) -> triton.runtime.Autotuner:
+        kernel_fn = (
+            self.dequantize_kernel_vectorized
+            if self.have_vectorized and use_vectorized
+            else self.dequantize_kernel
+        )
+        return triton.autotune(**kwargs)(kernel_fn)
 
     @maybestaticmethod
     @triton.jit
-    def dequantize_kernel(q_tensor_ptr, out_tensor_ptr, n_total_blocks, DTYPE: tl.constexpr, N_BLOCKS_PER_PROG: tl.constexpr, CTX: tl.constexpr) -> None:
+    def dequantize_kernel(
+        q_tensor_ptr,
+        out_tensor_ptr,
+        n_total_blocks,
+        DTYPE: tl.constexpr,
+        N_BLOCKS_PER_PROG: tl.constexpr,
+        CTX: tl.constexpr,
+    ) -> None:
         pid = tl.program_id(axis=0)
         start_block_idx = pid * N_BLOCKS_PER_PROG
         n_blocks = n_total_blocks - start_block_idx
@@ -91,6 +131,36 @@ class KernelImpl:
                         DTYPE=DTYPE,
                     )
 
+    @maybestaticmethod
+    @triton.jit
+    def dequantize_kernel_vectorized(
+        q_tensor_ptr,
+        out_tensor_ptr,
+        n_total_blocks,
+        DTYPE: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+        CTX: tl.constexpr,
+    ) -> None:
+        pid = tl.program_id(axis=0)
+        block_indices = pid * BLOCK_N + tl.arange(0, BLOCK_N)
+        mask_1d = block_indices < n_total_blocks
+
+        out_base_ptrs = out_tensor_ptr + block_indices * CTX.value.block_size
+        offsets_chunk = tl.arange(0, CTX.value.chunk_size)
+        base_ptrs = q_tensor_ptr + block_indices * CTX.value.type_size
+
+        for chunk_idx in tl.static_range(CTX.value.num_chunks):
+            dequant = CTX.value.dequantize_chunk_to_registers(
+                base_ptrs, mask_1d, chunk_idx, CTX, DTYPE
+            )
+            # Retain original pointer layouts for the one-shot kernel
+            out_chunk_ptrs = (
+                out_base_ptrs[:, None]
+                + chunk_idx * CTX.value.chunk_size
+                + offsets_chunk[None, :]
+            )
+            tl.store(out_chunk_ptrs, dequant, mask=mask_1d[:, None])
+
 
 class KernelDefinition:
     qtype: GGMLQuantizationType
@@ -98,28 +168,67 @@ class KernelDefinition:
     type_size: int
     kernel: KernelImpl
     autotuner_kernel: triton.runtime.Autotuner
+    use_vectorized: bool
 
-    def __init__(self, qtype: GGMLQuantizationType, kernel_class: type[KernelImpl]):
+    def __init__(
+        self,
+        qtype: GGMLQuantizationType,
+        *,
+        kernel_class: type[KernelImpl] | None = None,
+        kernel_instance: KernelImpl | None = None,
+        use_vectorized: bool = True,
+        **_kwargs: Any,
+    ):
         block_size, type_size = GGML_QUANT_SIZES[qtype]
-        kernel_instance = kernel_class(
-            block_size=tl.constexpr(block_size),
-            type_size=tl.constexpr(type_size),
-        )
+        if kernel_instance is None:
+            if kernel_class is None:
+                raise ValueError(
+                    "At least one of kernel_class or kernel_instance must be set",
+                )
+            kernel_instance = self.kernel = kernel_class(
+                block_size=tl.constexpr(block_size),
+                type_size=tl.constexpr(type_size),
+            )
+        elif kernel_class is not None:
+            raise ValueError(
+                "Only one of kernel_class or kernel_instance may be set",
+            )
+        self.use_vectorized = use_vectorized and self.have_vectorized
+        if self.use_vectorized:
+            default_configs = _DEFAULT_VECTORIZED_AUTOTUNE_CONFIGS
+            quant_configs = _VECTORIZED_QUANT_AUTOTUNE_CONFIGS
+        else:
+            default_configs = _DEFAULT_AUTOTUNE_CONFIGS
+            quant_configs = _QUANT_AUTOTUNE_CONFIGS
         autotuner_kernel = kernel_instance.get_autotuner(
-            configs=_AUTOTUNE_CONFIGS.get(
-                qtype.name.lower(), _DEFAULT_AUTOTUNE_CONFIGS
-            ),
+            use_vectorized=self.use_vectorized,
+            configs=quant_configs.get(qtype.name.lower(), default_configs),
             key=["n_total_blocks"],
         )
         self.qtype = qtype
         self.block_size = block_size
         self.type_size = type_size
-        self.kernel = kernel_instance
         self.autotuner_kernel = autotuner_kernel
+        # print(
+        #     f"DEFINED({qtype}): use vectorized={self.use_vectorized}, have vectorized={self.have_vectorized}, kernel={self.kernel}",
+        # )
 
+    @property
+    def have_vectorized(self) -> bool:
+        return self.kernel.have_vectorized
 
     @nocompiledecorator
-    def __call__(self, blocks: torch.Tensor, block_size: int, type_size: int, dtype: torch.dtype | None = None, _math_dtype: tl.dtype | None = tl.float32) -> torch.Tensor:
+    def __call__(
+        self,
+        blocks: torch.Tensor,
+        block_size: int = -1,
+        type_size: int = -1,
+        dtype: torch.dtype | None = None,
+        *,
+        _math_dtype: tl.dtype | None = tl.float32,
+        _use_vectorized: bool = True,
+        out_tensor: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         qtype, ggml_type_size = self.qtype, self.type_size
         if blocks.dtype != torch.uint8:
             if blocks.dtype == torch.int8:
@@ -150,12 +259,19 @@ class KernelDefinition:
                 f"GGUF Triton {qtype.name}: Unsupported output dtype {dtype}"
             )
 
-        out_tensor = torch.empty(
-            n_total_blocks * self.block_size, dtype=dtype, device=blocks.device
-        )
+        if out_tensor is None:
+            out_tensor = torch.empty(
+                n_total_blocks * self.block_size, dtype=dtype, device=blocks.device
+            )
 
-        def grid(meta: dict[str, Any]) -> tuple[int]:
-            return (triton.cdiv(n_total_blocks, meta["N_BLOCKS_PER_PROG"]),)
+        if self.use_vectorized:
+
+            def grid(meta: dict[str, Any]) -> tuple[int]:
+                return (triton.cdiv(n_total_blocks, meta["BLOCK_N"]),)
+        else:
+
+            def grid(meta: dict[str, Any]) -> tuple[int]:
+                return (triton.cdiv(n_total_blocks, meta["N_BLOCKS_PER_PROG"]),)
 
         self.autotuner_kernel[grid](
             blocks,
@@ -180,9 +296,52 @@ class KernelImpl_K_Quant(KernelImpl):
 
 @dataclass(frozen=True)
 class KernelImpl_Q2_K(KernelImpl_K_Quant):
+    vectorized: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(True))
+    chunk_size: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(32))
+    num_chunks: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(8))
+
     @maybestaticmethod
     @triton.jit
-    def dequantize_block_kernel(block_start_ptr, out_tensor_ptr, CTX: tl.constexpr, DTYPE: tl.constexpr) -> None:
+    def dequantize_chunk_to_registers(
+        base_ptrs, mask_1d, chunk_idx, CTX: tl.constexpr, DTYPE: tl.constexpr
+    ):
+        mask_2d = mask_1d[:, None]
+        offsets_32 = tl.arange(0, 32)
+
+        # 1. Load super-scales
+        d_ptrs = (base_ptrs + 80).to(tl.pointer_type(tl.float16))
+        dmin_ptrs = (base_ptrs + 82).to(tl.pointer_type(tl.float16))
+
+        d = tl.load(d_ptrs, mask=mask_1d, other=0.0).to(DTYPE)
+        dmin = tl.load(dmin_ptrs, mask=mask_1d, other=0.0).to(DTYPE)
+
+        # 2. Block scales (1 scale byte handles 16 elements)
+        scale_idx = chunk_idx * 2 + (offsets_32 // 16)
+        scale_ptrs = base_ptrs[:, None] + scale_idx[None, :]
+        scale_bytes = tl.load(scale_ptrs, mask=mask_2d, other=0)
+
+        dl_scale = (scale_bytes & 0x0F).to(DTYPE)
+        ml_scale = (scale_bytes >> 4).to(DTYPE)
+
+        dl = d[:, None] * dl_scale
+        ml = dmin[:, None] * ml_scale
+
+        # 3. Quantized values (qs)
+        qs_offset = 16 + (chunk_idx // 4) * 32
+        qs_ptrs = base_ptrs[:, None] + qs_offset + offsets_32[None, :]
+        qs_bytes = tl.load(qs_ptrs, mask=mask_2d, other=0)
+
+        shift = (chunk_idx % 4) * 2
+        q_vec = ((qs_bytes >> shift) & 3).to(DTYPE)
+
+        # 4. Dequantize
+        return dl * q_vec - ml
+
+    @maybestaticmethod
+    @triton.jit
+    def dequantize_block_kernel(
+        block_start_ptr, out_tensor_ptr, CTX: tl.constexpr, DTYPE: tl.constexpr
+    ) -> None:
         # Vector of offsets for a 16-element chunk
         offsets_16 = tl.arange(0, 16)
 
@@ -234,9 +393,63 @@ class KernelImpl_Q2_K(KernelImpl_K_Quant):
 
 @dataclass(frozen=True)
 class KernelImpl_Q3_K(KernelImpl_K_Quant):
+    vectorized: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(True))
+    chunk_size: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(32))
+    num_chunks: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(8))
+
     @maybestaticmethod
     @triton.jit
-    def dequantize_block_kernel(block_start_ptr, out_tensor_ptr, CTX: tl.constexpr, DTYPE: tl.constexpr) -> None:
+    def dequantize_chunk_to_registers(
+        base_ptrs, mask_1d, chunk_idx, CTX: tl.constexpr, DTYPE: tl.constexpr
+    ):
+        mask_2d = mask_1d[:, None]
+        offsets_32 = tl.arange(0, 32)
+
+        # 1. Super-scale
+        d_ptrs = (base_ptrs + 108).to(tl.pointer_type(tl.float16))
+        d_super_scale = tl.load(d_ptrs, mask=mask_1d, other=0.0).to(DTYPE)
+
+        # 2. Block scales
+        chunk_16 = chunk_idx * 2 + (offsets_32 // 16)
+
+        lscale_idx = chunk_16 % 8
+        lscale_shift = (chunk_16 // 8) * 4
+        lscale_ptrs = base_ptrs[:, None] + 96 + lscale_idx[None, :]
+        lscale_bytes = tl.load(lscale_ptrs, mask=mask_2d, other=0)
+        lscale_nibble = (lscale_bytes >> lscale_shift) & 0x0F
+
+        hscale_idx = chunk_16 % 4
+        hscale_shift = (chunk_16 // 4) * 2
+        hscale_ptrs = base_ptrs[:, None] + 104 + hscale_idx[None, :]
+        hscale_bytes = tl.load(hscale_ptrs, mask=mask_2d, other=0)
+        hscale_2bit = (hscale_bytes >> hscale_shift) & 0x03
+
+        scale_6bit = lscale_nibble | (hscale_2bit << 4)
+        final_scale = d_super_scale[:, None] * (scale_6bit.to(tl.int8) - 32).to(DTYPE)
+
+        # 3. ql (lower 2 bits)
+        ql_offset = 32 + (chunk_idx // 4) * 32
+        ql_ptrs = base_ptrs[:, None] + ql_offset + offsets_32[None, :]
+        ql_bytes = tl.load(ql_ptrs, mask=mask_2d, other=0)
+        ql_shift = (chunk_idx % 4) * 2
+        ql_vec = (ql_bytes >> ql_shift) & 3
+
+        # 4. qh (higher 1 bit, inverted)
+        qh_ptrs = base_ptrs[:, None] + offsets_32[None, :]
+        qh_bytes = tl.load(qh_ptrs, mask=mask_2d, other=0)
+        # Using chunk_idx as the bit-shift natively replaces the old `qh_source_row` logic!
+        qh_vec = ((qh_bytes >> chunk_idx) & 1) ^ 1
+
+        # 5. Combine and dequantize
+        q_vec = ql_vec.to(tl.int8) - (qh_vec.to(tl.int8) << 2)
+
+        return final_scale * q_vec.to(DTYPE)
+
+    @maybestaticmethod
+    @triton.jit
+    def dequantize_block_kernel(
+        block_start_ptr, out_tensor_ptr, CTX: tl.constexpr, DTYPE: tl.constexpr
+    ) -> None:
         # Vector of offsets for a 16-element chunk (one row of the output matrix)
         offsets_16 = tl.arange(0, 16)
 
@@ -300,10 +513,16 @@ class KernelImpl_Q3_K(KernelImpl_K_Quant):
 
 @dataclass(frozen=True)
 class KernelImpl_Q4_K(KernelImpl_K_Quant):
+    vectorized: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(True))
+    chunk_size: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(64))
+    num_chunks: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(4))
+
     # Helper function, shared by Q4_K and Q5_K.
     @maybestaticmethod
     @triton.jit
-    def get_scales_min(k_idx: int, d_sc_word: tl.tensor, m_word: tl.tensor, m_sc_word: tl.tensor) -> tl.tuple:
+    def get_scales_min(
+        k_idx: int, d_sc_word: tl.tensor, m_word: tl.tensor, m_sc_word: tl.tensor
+    ) -> tl.tuple:
         if k_idx < 4:
             k_idx_x8 = k_idx * 8
             d_sc_byte = d_sc_word >> k_idx_x8
@@ -321,7 +540,51 @@ class KernelImpl_Q4_K(KernelImpl_K_Quant):
 
     @maybestaticmethod
     @triton.jit
-    def dequantize_block_kernel(block_start_ptr, out_tensor_ptr, CTX: tl.constexpr, DTYPE: tl.constexpr) -> None:
+    def dequantize_chunk_to_registers(
+        base_ptrs,
+        mask_1d,
+        chunk_idx,
+        CTX: tl.constexpr,
+        DTYPE: tl.constexpr,
+    ):
+        d_ptrs = base_ptrs.to(tl.pointer_type(tl.float16))
+        d = tl.load(d_ptrs, mask=mask_1d, other=0.0).to(DTYPE)
+        dmin = tl.load(d_ptrs + 1, mask=mask_1d, other=0.0).to(DTYPE)
+
+        scales_ptrs_u32 = (base_ptrs + 4).to(tl.pointer_type(tl.uint32))
+        d_sc_word = tl.load(scales_ptrs_u32, mask=mask_1d, other=0)
+        m_word = tl.load(scales_ptrs_u32 + 1, mask=mask_1d, other=0)
+        m_sc_word = tl.load(scales_ptrs_u32 + 2, mask=mask_1d, other=0)
+
+        k_idx = 2 * chunk_idx
+        sc_a, m_a = CTX.value.get_scales_min(k_idx, d_sc_word, m_word, m_sc_word)
+        sc_b, m_b = CTX.value.get_scales_min(k_idx + 1, d_sc_word, m_word, m_sc_word)
+
+        # Modulo trick for 64 elements (wrapping the 32 bytes)
+        offsets_64 = tl.arange(0, 64)
+        qs_byte_idx = offsets_64 % 32
+        qs_ptrs = base_ptrs[:, None] + 16 + chunk_idx * 32 + qs_byte_idx[None, :]
+        qs_bytes = tl.load(qs_ptrs, mask=mask_1d[:, None], other=0)
+
+        is_high = offsets_64[None, :] >= 32
+        qs_nibbles = tl.where(is_high, qs_bytes >> 4, qs_bytes) & 0x0F
+        qs_vals = qs_nibbles.to(DTYPE)
+
+        # Select the correct scales for the high vs low sides
+        current_d = tl.where(
+            is_high, (d * sc_b.to(DTYPE))[:, None], (d * sc_a.to(DTYPE))[:, None]
+        )
+        current_dm = tl.where(
+            is_high, (dmin * m_b.to(DTYPE))[:, None], (dmin * m_a.to(DTYPE))[:, None]
+        )
+
+        return current_d * qs_vals - current_dm
+
+    @maybestaticmethod
+    @triton.jit
+    def dequantize_block_kernel(
+        block_start_ptr, out_tensor_ptr, CTX: tl.constexpr, DTYPE: tl.constexpr
+    ) -> None:
         offsets_32 = tl.arange(0, 32)
         offsets_scale = offsets_32 + 4 + CTX.value.k_scale_size
 
@@ -357,7 +620,8 @@ class KernelImpl_Q4_K(KernelImpl_K_Quant):
             qs_bytes_chunk = tl.load(chunk_qs_ptr)
 
             qs_low = (qs_bytes_chunk & 0x0F).to(DTYPE)
-            qs_high = (qs_bytes_chunk >> 4).to(DTYPE)
+            # qs_high = (qs_bytes_chunk >> 4).to(DTYPE)
+            qs_high = ((qs_bytes_chunk >> 4) & 0x0F).to(DTYPE)
 
             dequant_low = current_d_a * qs_low - current_dm_a
             dequant_high = current_d_b * qs_high - current_dm_b
@@ -370,9 +634,62 @@ class KernelImpl_Q4_K(KernelImpl_K_Quant):
 
 @dataclass(frozen=True)
 class KernelImpl_Q5_K(KernelImpl_Q4_K):
+    vectorized: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(True))
+    chunk_size: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(32))
+    num_chunks: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(8))
+
     @maybestaticmethod
     @triton.jit
-    def dequantize_block_kernel(block_start_ptr, out_tensor_ptr, CTX: tl.constexpr, DTYPE: tl.constexpr) -> None:
+    def dequantize_chunk_to_registers(
+        base_ptrs,
+        mask_1d,
+        chunk_idx,
+        CTX: tl.constexpr,
+        DTYPE: tl.constexpr,
+    ):
+        mask_2d = mask_1d[:, None]
+        offsets_32 = tl.arange(0, 32)
+
+        # 1. Super-scales
+        d_ptrs = base_ptrs.to(tl.pointer_type(tl.float16))
+        d = tl.load(d_ptrs, mask=mask_1d, other=0.0).to(DTYPE)
+        dmin = tl.load(d_ptrs + 1, mask=mask_1d, other=0.0).to(DTYPE)
+
+        # 2. Block scales
+        scales_ptrs_u32 = (base_ptrs + 4).to(tl.pointer_type(tl.uint32))
+        d_sc_word = tl.load(scales_ptrs_u32, mask=mask_1d, other=0)
+        m_word = tl.load(scales_ptrs_u32 + 1, mask=mask_1d, other=0)
+        m_sc_word = tl.load(scales_ptrs_u32 + 2, mask=mask_1d, other=0)
+
+        sc, m = CTX.value.get_scales_min(chunk_idx, d_sc_word, m_word, m_sc_word)
+        final_d = d * sc.to(DTYPE)
+        final_dm = dmin * m.to(DTYPE)
+
+        # 3. QL (Lower 4 bits)
+        # qs offsets start at 48 (16 byte header + 32 byte qh)
+        qs_byte_offset = (chunk_idx // 2) * 32
+        qs_ptrs = base_ptrs[:, None] + 48 + qs_byte_offset + offsets_32[None, :]
+        qs_bytes = tl.load(qs_ptrs, mask=mask_2d, other=0)
+
+        # Use ALU Mux to avoid branching on the chunk index
+        is_even = (chunk_idx % 2) == 0
+        ql = tl.where(is_even, qs_bytes & 0x0F, (qs_bytes >> 4) & 0x0F)
+
+        # 4. QH (High 1 bit)
+        # qh offsets start at 16
+        qh_ptrs = base_ptrs[:, None] + 16 + offsets_32[None, :]
+        qh_bytes = tl.load(qh_ptrs, mask=mask_2d, other=0)
+        qh_bit = (qh_bytes >> chunk_idx) & 0x01
+
+        # Combine and dequantize
+        q = ql | (qh_bit << 4)
+        return final_d[:, None] * q.to(DTYPE) - final_dm[:, None]
+
+    @maybestaticmethod
+    @triton.jit
+    def dequantize_block_kernel(
+        block_start_ptr, out_tensor_ptr, CTX: tl.constexpr, DTYPE: tl.constexpr
+    ) -> None:
         offsets_32 = tl.arange(0, 32)
         offsets_scale = offsets_32 + 4 + CTX.value.k_scale_size
 
@@ -417,9 +734,59 @@ class KernelImpl_Q5_K(KernelImpl_Q4_K):
 
 @dataclass(frozen=True)
 class KernelImpl_Q6_K(KernelImpl_K_Quant):
+    vectorized: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(True))
+    chunk_size: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(32))
+    num_chunks: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(8))
+
     @maybestaticmethod
     @triton.jit
-    def dequantize_block_kernel(block_start_ptr, out_tensor_ptr, CTX: tl.constexpr, DTYPE: tl.constexpr) -> None:
+    def dequantize_chunk_to_registers(
+        base_ptrs,
+        mask_1d,
+        chunk_idx,
+        CTX: tl.constexpr,
+        DTYPE: tl.constexpr,
+    ):
+        mask_2d = mask_1d[:, None]
+        offsets_32 = tl.arange(0, 32)
+
+        # 1. Super-scale
+        d_ptrs = (base_ptrs + 208).to(tl.pointer_type(tl.float16))
+        d_super_scale = tl.load(d_ptrs, mask=mask_1d, other=0.0).to(DTYPE)
+
+        # 2. QL (Lower 4 bits)
+        ql_offset = (chunk_idx % 2) * 32 + (chunk_idx // 4) * 64
+        ql_ptrs = base_ptrs[:, None] + ql_offset + offsets_32[None, :]
+        ql_bytes = tl.load(ql_ptrs, mask=mask_2d, other=0)
+
+        is_even = ((chunk_idx // 2) % 2) == 0
+        ql_vec = tl.where(is_even, ql_bytes & 0x0F, (ql_bytes >> 4) & 0x0F)
+
+        # 3. QH (High 2 bits)
+        qh_offset = 128 + (chunk_idx // 4) * 32
+        qh_ptrs = base_ptrs[:, None] + qh_offset + offsets_32[None, :]
+        qh_bytes = tl.load(qh_ptrs, mask=mask_2d, other=0)
+
+        bit_shift = (chunk_idx % 4) * 2
+        qh_vec = (qh_bytes >> bit_shift) & 0x03
+
+        # Combine
+        q_vec = (ql_vec | (qh_vec << 4)).to(tl.int8) - 32
+
+        # 4. Scales (int8)
+        scale_idx = chunk_idx * 2 + (offsets_32 // 16)
+        scale_ptrs = base_ptrs[:, None] + 192 + scale_idx[None, :]
+        scale_ptrs_i8 = scale_ptrs.to(tl.pointer_type(tl.int8))
+        scales = tl.load(scale_ptrs_i8, mask=mask_2d, other=0).to(DTYPE)
+
+        # Compute and return!
+        return q_vec.to(DTYPE) * (d_super_scale[:, None] * scales)
+
+    @maybestaticmethod
+    @triton.jit
+    def dequantize_block_kernel(
+        block_start_ptr, out_tensor_ptr, CTX: tl.constexpr, DTYPE: tl.constexpr
+    ) -> None:
         offsets_32 = tl.arange(0, 32)
         mask_16 = offsets_32 < 16
 
@@ -488,9 +855,40 @@ class KernelImpl_Legacy(KernelImpl):
 
 @dataclass(frozen=True)
 class KernelImpl_Q4_0(KernelImpl_Legacy):
+    vectorized: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(True))
+    chunk_size: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(32))
+    num_chunks: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(1))
+
     @maybestaticmethod
     @triton.jit
-    def dequantize_block_kernel(block_start_ptr, out_tensor_ptr, CTX: tl.constexpr, DTYPE: tl.constexpr) -> None:
+    def dequantize_chunk_to_registers(
+        base_ptrs,
+        mask_1d,
+        chunk_idx,
+        CTX: tl.constexpr,
+        DTYPE: tl.constexpr,
+    ):
+        d_ptrs = base_ptrs.to(tl.pointer_type(tl.float16))
+        d = tl.load(d_ptrs, mask=mask_1d, other=0.0).to(DTYPE)
+
+        # Modulo trick: loads [BLOCK_N, 32] layout natively by wrapping the 16 bytes!
+        offsets_32 = tl.arange(0, 32)
+        qs_byte_idx = offsets_32 % 16
+        qs_ptrs = base_ptrs[:, None] + 2 + qs_byte_idx[None, :]
+        qs_bytes = tl.load(qs_ptrs, mask=mask_1d[:, None], other=0)
+
+        # Use an ALU mux to split high/low nibbles in the 32-element register
+        is_high = offsets_32[None, :] >= 16
+        qs_nibbles = tl.where(is_high, qs_bytes >> 4, qs_bytes)
+        q_vals = (qs_nibbles & 0x0F).to(tl.int8, bitcast=True) - 8
+
+        return q_vals.to(DTYPE) * d[:, None]
+
+    @maybestaticmethod
+    @triton.jit
+    def dequantize_block_kernel(
+        block_start_ptr, out_tensor_ptr, CTX: tl.constexpr, DTYPE: tl.constexpr
+    ) -> None:
         # Vector of offsets for the 16 bytes of quantized data
         offsets_16 = tl.arange(0, 16)
 
@@ -520,9 +918,41 @@ class KernelImpl_Q4_0(KernelImpl_Legacy):
 
 @dataclass(frozen=True)
 class KernelImpl_Q4_1(KernelImpl_Legacy):
+    vectorized: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(True))
+    chunk_size: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(32))
+    num_chunks: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(1))
+
     @maybestaticmethod
     @triton.jit
-    def dequantize_block_kernel( block_start_ptr, out_tensor_ptr, CTX: tl.constexpr, DTYPE: tl.constexpr) -> None:
+    def dequantize_chunk_to_registers(
+        base_ptrs, mask_1d, chunk_idx, CTX: tl.constexpr, DTYPE: tl.constexpr
+    ):
+        # 1. Load scale 'd' and min 'm'
+        d_ptrs = base_ptrs.to(tl.pointer_type(tl.float16))
+        d = tl.load(d_ptrs, mask=mask_1d, other=0.0).to(DTYPE)
+
+        m_ptrs = (base_ptrs + 2).to(tl.pointer_type(tl.float16))
+        m = tl.load(m_ptrs, mask=mask_1d, other=0.0).to(DTYPE)
+
+        # 2. Modulo wrapping for 16-byte memory layout
+        offsets_32 = tl.arange(0, 32)
+        qs_byte_idx = offsets_32 % 16
+        qs_ptrs = base_ptrs[:, None] + 4 + qs_byte_idx[None, :]
+        qs_bytes = tl.load(qs_ptrs, mask=mask_1d[:, None], other=0)
+
+        # 3. Unpack into 32 values
+        is_high = offsets_32[None, :] >= 16
+        qs_nibbles = tl.where(is_high, qs_bytes >> 4, qs_bytes)
+        q_vals = (qs_nibbles & 0x0F).to(DTYPE)
+
+        # 4. Dequantize
+        return d[:, None] * q_vals + m[:, None]
+
+    @maybestaticmethod
+    @triton.jit
+    def dequantize_block_kernel(
+        block_start_ptr, out_tensor_ptr, CTX: tl.constexpr, DTYPE: tl.constexpr
+    ) -> None:
         # Vector of offsets for the 16 bytes of quantized data
         offsets_16 = tl.arange(0, 16)
 
@@ -550,39 +980,125 @@ class KernelImpl_Q4_1(KernelImpl_Legacy):
 
 @dataclass(frozen=True)
 class KernelImpl_Q5_0(KernelImpl_Legacy):
+    vectorized: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(True))
+    chunk_size: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(32))
+    num_chunks: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(1))
+
     @maybestaticmethod
     @triton.jit
-    def dequantize_block_kernel(block_start_ptr, out_tensor_ptr, CTX: tl.constexpr, DTYPE: tl.constexpr) -> None:
+    def dequantize_chunk_to_registers(
+        base_ptrs, mask_1d, chunk_idx, CTX: tl.constexpr, DTYPE: tl.constexpr
+    ):
+        # 1. Load scale 'd'
+        d_ptrs = base_ptrs.to(tl.pointer_type(tl.float16))
+        d = tl.load(d_ptrs, mask=mask_1d, other=0.0).to(DTYPE)
+
+        offsets_32 = tl.arange(0, 32)
+
+        # We map each of the 32 elements to the exact 1-byte memory address that holds its high bit.
+        qh_byte_idx = offsets_32 // 8
+        qh_bit_idx = offsets_32 % 8
+
+        qh_ptrs = base_ptrs[:, None] + 2 + qh_byte_idx[None, :]
+        qh_bytes = tl.load(qh_ptrs, mask=mask_1d[:, None], other=0)
+
+        # Extract the specific bit for this element
+        qh_bit = (qh_bytes >> qh_bit_idx[None, :]) & 1
+
+        # 2. Load 16 bytes of low-bits (qs)
+        qs_byte_idx = offsets_32 % 16
+        qs_ptrs = base_ptrs[:, None] + 6 + qs_byte_idx[None, :]
+        qs_bytes = tl.load(qs_ptrs, mask=mask_1d[:, None], other=0)
+
+        # 3. Extract Low bits
+        is_high = offsets_32[None, :] >= 16
+        ql = tl.where(is_high, qs_bytes >> 4, qs_bytes) & 0x0F
+
+        # 4. Combine and apply scale
+        q_vals = (ql | (qh_bit << 4)).to(tl.int8) - 16
+
+        return d[:, None] * q_vals.to(DTYPE)
+
+    @maybestaticmethod
+    @triton.jit
+    def dequantize_block_kernel(
+        block_start_ptr, out_tensor_ptr, CTX: tl.constexpr, DTYPE: tl.constexpr
+    ) -> None:
         offsets_16 = tl.arange(0, 16)
-        offsets_4 = tl.arange(0, 4)
 
         d_ptr = block_start_ptr
         qh_ptr = block_start_ptr + 2
         qs_ptr = block_start_ptr + 6
 
         d = tl.load(d_ptr.to(tl.pointer_type(tl.float16))).to(DTYPE)
-        qh_word = tl.sum(tl.load(qh_ptr + offsets_4).to(tl.uint32) << (offsets_4 << 3))
-
         qs_bytes_16 = tl.load(qs_ptr + offsets_16)
 
+        # --- Low 16 elements (indices 0 to 15) ---
+        qh_byte_low = offsets_16 // 8
+        qh_bit_low = offsets_16 % 8
+        qh_bytes_loaded_low = tl.load(qh_ptr + qh_byte_low)
+
         ql_low = qs_bytes_16 & 0x0F
-        qh_low = (qh_word >> offsets_16) & 1
+        qh_low = (qh_bytes_loaded_low >> qh_bit_low) & 1
         q_low = (ql_low | (qh_low << 4)).to(tl.int8) - 16
-        dequant_low = d * q_low.to(DTYPE)  # Shape: [16]
+        dequant_low = d * q_low.to(DTYPE)
+
+        # --- High 16 elements (indices 16 to 31) ---
+        offsets_16_high = offsets_16 + 16
+        qh_byte_high = offsets_16_high // 8
+        qh_bit_high = offsets_16_high % 8
+        qh_bytes_loaded_high = tl.load(qh_ptr + qh_byte_high)
 
         ql_high = qs_bytes_16 >> 4
-        qh_high = (qh_word >> (offsets_16 + 16)) & 1
+        qh_high = (qh_bytes_loaded_high >> qh_bit_high) & 1
         q_high = (ql_high | (qh_high << 4)).to(tl.int8) - 16
-        dequant_high = d * q_high.to(DTYPE)  # Shape: [16]
+        dequant_high = d * q_high.to(DTYPE)
 
         CTX.value.store_output(out_tensor_ptr, dequant_low, dequant_high)
 
 
 @dataclass(frozen=True)
 class KernelImpl_Q5_1(KernelImpl_Legacy):
+    vectorized: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(True))
+    chunk_size: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(32))
+    num_chunks: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(1))
+
     @maybestaticmethod
     @triton.jit
-    def dequantize_block_kernel(block_start_ptr, out_tensor_ptr, CTX: tl.constexpr, DTYPE: tl.constexpr) -> None:
+    def dequantize_chunk_to_registers(
+        base_ptrs, mask_1d, chunk_idx, CTX: tl.constexpr, DTYPE: tl.constexpr
+    ):
+        # 1. Load 'd', 'm' and high-bit word 'qh'
+        d_ptrs = base_ptrs.to(tl.pointer_type(tl.float16))
+        d = tl.load(d_ptrs, mask=mask_1d, other=0.0).to(DTYPE)
+
+        m_ptrs = (base_ptrs + 2).to(tl.pointer_type(tl.float16))
+        m = tl.load(m_ptrs, mask=mask_1d, other=0.0).to(DTYPE)
+
+        qh_ptrs = (base_ptrs + 4).to(tl.pointer_type(tl.uint32))
+        qh_word = tl.load(qh_ptrs, mask=mask_1d, other=0)
+
+        # 2. Load 16 bytes of low-bits
+        offsets_32 = tl.arange(0, 32)
+        qs_byte_idx = offsets_32 % 16
+        qs_ptrs = base_ptrs[:, None] + 8 + qs_byte_idx[None, :]
+        qs_bytes = tl.load(qs_ptrs, mask=mask_1d[:, None], other=0)
+
+        # 3. Extract Lows and Highs
+        is_high = offsets_32[None, :] >= 16
+        ql = tl.where(is_high, qs_bytes >> 4, qs_bytes) & 0x0F
+        qh_bit = (qh_word[:, None] >> offsets_32[None, :]) & 1
+
+        # 4. Combine and apply scale/bias
+        q_vals = (ql | (qh_bit << 4)).to(DTYPE)
+
+        return d[:, None] * q_vals + m[:, None]
+
+    @maybestaticmethod
+    @triton.jit
+    def dequantize_block_kernel(
+        block_start_ptr, out_tensor_ptr, CTX: tl.constexpr, DTYPE: tl.constexpr
+    ) -> None:
         offsets_16 = tl.arange(0, 16)
 
         # Data layout: 2 bytes 'd', 2 bytes 'm', 4 bytes 'qh', 16 bytes 'qs'
@@ -617,33 +1133,73 @@ class KernelImpl_Q5_1(KernelImpl_Legacy):
 
 @dataclass(frozen=True)
 class KernelImpl_Q8_0(KernelImpl_Legacy):
+    vectorized: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(True))
+    chunk_size: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(32))
+    num_chunks: tl.constexpr = dcfield(default_factory=lambda: tl.constexpr(1))
+
     @maybestaticmethod
     @triton.jit
-    def dequantize_block_kernel(block_start_ptr, out_tensor_ptr, CTX: tl.constexpr, DTYPE: tl.constexpr) -> None:
+    def dequantize_chunk_to_registers(
+        base_ptrs, mask_1d, chunk_idx, CTX: tl.constexpr, DTYPE: tl.constexpr
+    ):
+        d_ptrs = base_ptrs.to(tl.pointer_type(tl.float16))
+        d = tl.load(d_ptrs, mask=mask_1d, other=0.0).to(DTYPE)
+
+        offsets_32 = tl.arange(0, 32)
+        x_ptrs = base_ptrs[:, None] + 2 + offsets_32[None, :]
+        x = tl.load(
+            x_ptrs.to(tl.pointer_type(tl.int8)), mask=mask_1d[:, None], other=0
+        ).to(DTYPE)
+
+        return d[:, None] * x
+
+    @maybestaticmethod
+    @triton.jit
+    def dequantize_block_kernel(
+        block_start_ptr, out_tensor_ptr, CTX: tl.constexpr, DTYPE: tl.constexpr
+    ) -> None:
         offsets_32 = tl.arange(0, 32)
         d_ptr = block_start_ptr.to(tl.pointer_type(tl.float16), bitcast=True) + 0
         x_ptr = (
             block_start_ptr.to(tl.pointer_type(tl.int8), bitcast=True) + 2 + offsets_32
         )
         output_ptr = out_tensor_ptr + offsets_32
-        d = d = tl.load(d_ptr).to(DTYPE)
+        d = tl.load(d_ptr).to(DTYPE)
         x = tl.load(x_ptr).to(DTYPE)
         output_ptr.store(d * x)
 
 
-dequantize_functions: dict[GGMLQuantizationType, KernelDefinition] = {
+_type_kernel_class_map: dict[GGMLQuantizationType, type[KernelImpl]] = {
     # Legancy quants
-    GQT.Q4_0: KernelDefinition(GQT.Q4_0, KernelImpl_Q4_0),
-    GQT.Q4_1: KernelDefinition(GQT.Q4_1, KernelImpl_Q4_1),
-    GQT.Q5_0: KernelDefinition(GQT.Q5_0, KernelImpl_Q5_0),
-    GQT.Q5_1: KernelDefinition(GQT.Q5_1, KernelImpl_Q5_1),
-    GQT.Q8_0: KernelDefinition(GQT.Q8_0, KernelImpl_Q8_0),
+    GGMLQuantizationType.Q4_0: KernelImpl_Q4_0,
+    GGMLQuantizationType.Q4_1: KernelImpl_Q4_1,
+    GGMLQuantizationType.Q5_0: KernelImpl_Q5_0,
+    GGMLQuantizationType.Q5_1: KernelImpl_Q5_1,
+    GGMLQuantizationType.Q8_0: KernelImpl_Q8_0,
     # K-quants
-    GQT.Q2_K: KernelDefinition(GQT.Q2_K, KernelImpl_Q2_K),
-    GQT.Q3_K: KernelDefinition(GQT.Q3_K, KernelImpl_Q3_K),
-    GQT.Q4_K: KernelDefinition(GQT.Q4_K, KernelImpl_Q4_K),
-    GQT.Q5_K: KernelDefinition(GQT.Q5_K, KernelImpl_Q5_K),
-    GQT.Q6_K: KernelDefinition(GQT.Q6_K, KernelImpl_Q6_K),
+    GGMLQuantizationType.Q2_K: KernelImpl_Q2_K,
+    GGMLQuantizationType.Q3_K: KernelImpl_Q3_K,
+    GGMLQuantizationType.Q4_K: KernelImpl_Q4_K,
+    GGMLQuantizationType.Q5_K: KernelImpl_Q5_K,
+    GGMLQuantizationType.Q6_K: KernelImpl_Q6_K,
 }
 
-__all__ = ("dequantize_functions",)
+
+def build_dequantize_functions(
+    **kwargs,
+) -> dict[GGMLQuantizationType, KernelDefinition]:
+    return {
+        qtype: KernelDefinition(qtype, kernel_class=kclass, **kwargs)
+        for qtype, kclass in _type_kernel_class_map.items()
+    }
+
+
+dequantize_functions: dict[GGMLQuantizationType, KernelDefinition] = (
+    build_dequantize_functions()
+)
+
+dequantize_functions_legacy: dict[GGMLQuantizationType, KernelDefinition] = (
+    build_dequantize_functions(use_vectorized=False)
+)
+
+__all__ = ("dequantize_functions", "dequantize_functions_legacy")

--- a/nodes.py
+++ b/nodes.py
@@ -16,6 +16,7 @@ import folder_paths
 from .ops import GGMLOps, move_patch_to_device
 from .loader import gguf_sd_loader, gguf_clip_loader
 from .dequant import is_quantized, is_torch_compatible
+from . import dequant
 
 from . import dequant
 
@@ -149,22 +150,39 @@ class UnetLoaderGGUF:
     CATEGORY = "bootleg"
     TITLE = "Unet Loader (GGUF)"
 
-    def load_unet(self, unet_name, dequant_dtype=None, patch_dtype=None, patch_on_device=None):
-        ops = GGMLOps()
+    def load_unet(self, unet_name, dequant_dtype=None, patch_dtype=None, patch_on_device=None, compile=False):
+        dequantize_function = dequantize_handlers = None
+        if compile:
+            compile_opts={}
+            try:
+                dequantize_function = torch.compile(dequant.dequantize, **compile_opts)
+                dequantize_handlers = {
+                    k: torch.compile(v, **compile_opts)
+                    for k, v in dequant.dequantize_functions.items()
+                }
+            except Exception as exc:
+                dequantize_function = dequantize_handlers = None
+                print(f"GGUF: Failed to compile dequant functions: {exc}")
 
-        if dequant_dtype in ("default", None):
-            ops.Linear.dequant_dtype = None
-        elif dequant_dtype in ["target"]:
-            ops.Linear.dequant_dtype = dequant_dtype
-        else:
-            ops.Linear.dequant_dtype = getattr(torch, dequant_dtype)
+        if dequant_dtype == "default":
+            dequant_dtype = None
+        elif dequant_dtype and dequant_dtype != "target":
+            dequant_dtype = getattr(torch, dequant_dtype)
+        if patch_dtype == "default":
+            patch_dtype = None
+        elif patch_dtype and patch_dtype != "target":
+            patch_dtype = getattr(torch, patch_dtype)
 
-        if patch_dtype in ("default", None):
-            ops.Linear.patch_dtype = None
-        elif patch_dtype in ["target"]:
-            ops.Linear.patch_dtype = patch_dtype
-        else:
-            ops.Linear.patch_dtype = getattr(torch, patch_dtype)
+        config = dequant.GGUFConfig(
+            dequant_dtype = dequant_dtype,
+            patch_dtype = patch_dtype,
+            patch_on_device = patch_on_device,
+            compile = compile,
+            dequantize_function = dequantize_function,
+            dequantize_handlers = dequantize_handlers,
+        )
+        print(f"\nGGUF: Using config {config}")
+        ops = GGMLOps(ggufconfig=config)
 
         # init model
         unet_path = folder_paths.get_full_path("unet", unet_name)
@@ -195,6 +213,7 @@ class UnetLoaderGGUFAdvanced(UnetLoaderGGUF):
                 "dequant_dtype": (["default", "target", "float32", "float16", "bfloat16"], {"default": "default"}),
                 "patch_dtype": (["default", "target", "float32", "float16", "bfloat16"], {"default": "default"}),
                 "patch_on_device": ("BOOLEAN", {"default": False}),
+                "compile": ("BOOLEAN", {"default": False, "tooltip": "When enabled, the GGUF dequantization functions will be compiled. This is generally a significant performance benefit."}),
             }
         }
     TITLE = "Unet Loader (GGUF/Advanced)"

--- a/nodes.py
+++ b/nodes.py
@@ -18,8 +18,6 @@ from .loader import gguf_sd_loader, gguf_clip_loader
 from .dequant import is_quantized, is_torch_compatible
 from . import dequant
 
-from . import dequant
-
 def update_folder_names_and_paths(key, targets=[]):
     # check for existing key
     base = folder_paths.folder_names_and_paths.get(key, ([], {}))
@@ -150,9 +148,9 @@ class UnetLoaderGGUF:
     CATEGORY = "bootleg"
     TITLE = "Unet Loader (GGUF)"
 
-    def load_unet(self, unet_name, dequant_dtype=None, patch_dtype=None, patch_on_device=None, compile=False):
+    def load_unet(self, unet_name, dequant_dtype=None, patch_dtype=None, patch_on_device=None, optimize="none"):
         dequantize_function = dequantize_handlers = None
-        if compile:
+        if optimize == "compile":
             compile_opts={}
             try:
                 dequantize_function = torch.compile(dequant.dequantize, **compile_opts)
@@ -163,6 +161,8 @@ class UnetLoaderGGUF:
             except Exception as exc:
                 dequantize_function = dequantize_handlers = None
                 print(f"GGUF: Failed to compile dequant functions: {exc}")
+        elif optimize == "triton":
+            dequantize_handlers = dequant.dequantize_functions | dequant.triton_dequantize_functions
 
         if dequant_dtype == "default":
             dequant_dtype = None
@@ -177,7 +177,7 @@ class UnetLoaderGGUF:
             dequant_dtype = dequant_dtype,
             patch_dtype = patch_dtype,
             patch_on_device = patch_on_device,
-            compile = compile,
+            optimize=optimize,
             dequantize_function = dequantize_function,
             dequantize_handlers = dequantize_handlers,
         )
@@ -213,7 +213,7 @@ class UnetLoaderGGUFAdvanced(UnetLoaderGGUF):
                 "dequant_dtype": (["default", "target", "float32", "float16", "bfloat16"], {"default": "default"}),
                 "patch_dtype": (["default", "target", "float32", "float16", "bfloat16"], {"default": "default"}),
                 "patch_on_device": ("BOOLEAN", {"default": False}),
-                "compile": ("BOOLEAN", {"default": False, "tooltip": "When enabled, the GGUF dequantization functions will be compiled. This is generally a significant performance benefit."}),
+                "optimize": (("none", "compile", "triton"), {"default": "none"}),
             }
         }
     TITLE = "Unet Loader (GGUF/Advanced)"
@@ -339,31 +339,6 @@ class QuadrupleCLIPLoaderGGUF(CLIPLoaderGGUF):
         clip_type = getattr(comfy.sd.CLIPType, type.upper(), comfy.sd.CLIPType.STABLE_DIFFUSION)
         return (self.load_patcher(clip_paths, clip_type, self.load_data(clip_paths)),)
 
-class GGUFTritonToggle:
-    @classmethod
-    def INPUT_TYPES(cls) -> dict:
-        return {
-            "required": {
-                "passthrough_model": ("MODEL",),
-                "enabled": (
-                    "BOOLEAN",
-                    {"default": bool(dequant.triton_dequantize_functions)},
-                )
-            }
-        }
-
-    TITLE = "Triton toggle (GGUF)"
-    RETURN_TYPES = ("MODEL",)
-    FUNCTION = "go"
-    CATEGORY = "hacks"
-
-    @classmethod
-    def go(cls, *, enabled: bool, passthrough_model: object) -> tuple[object]:
-        dequant.ALLOW_TRITON = dequant.triton_dequantize_functions and enabled
-        if enabled:
-            print(f"\nGGUF: Enabling Triton, supported quants: {tuple(dequant.triton_dequantize_functions)}")
-        return (passthrough_model.clone(),)
-
 
 NODE_CLASS_MAPPINGS = {
     "UnetLoaderGGUF": UnetLoaderGGUF,
@@ -372,6 +347,5 @@ NODE_CLASS_MAPPINGS = {
     "TripleCLIPLoaderGGUF": TripleCLIPLoaderGGUF,
     "QuadrupleCLIPLoaderGGUF": QuadrupleCLIPLoaderGGUF,
     "UnetLoaderGGUFAdvanced": UnetLoaderGGUFAdvanced,
-    "GGUFTritonToggle": GGUFTritonToggle,
 }
 

--- a/nodes.py
+++ b/nodes.py
@@ -17,6 +17,8 @@ from .ops import GGMLOps, move_patch_to_device
 from .loader import gguf_sd_loader, gguf_clip_loader
 from .dequant import is_quantized, is_torch_compatible
 
+from . import dequant
+
 def update_folder_names_and_paths(key, targets=[]):
     # check for existing key
     base = folder_paths.folder_names_and_paths.get(key, ([], {}))
@@ -318,6 +320,32 @@ class QuadrupleCLIPLoaderGGUF(CLIPLoaderGGUF):
         clip_type = getattr(comfy.sd.CLIPType, type.upper(), comfy.sd.CLIPType.STABLE_DIFFUSION)
         return (self.load_patcher(clip_paths, clip_type, self.load_data(clip_paths)),)
 
+class GGUFTritonToggle:
+    @classmethod
+    def INPUT_TYPES(cls) -> dict:
+        return {
+            "required": {
+                "passthrough_model": ("MODEL",),
+                "enabled": (
+                    "BOOLEAN",
+                    {"default": bool(dequant.triton_dequantize_functions)},
+                )
+            }
+        }
+
+    TITLE = "Triton toggle (GGUF)"
+    RETURN_TYPES = ("MODEL",)
+    FUNCTION = "go"
+    CATEGORY = "hacks"
+
+    @classmethod
+    def go(cls, *, enabled: bool, passthrough_model: object) -> tuple[object]:
+        dequant.ALLOW_TRITON = dequant.triton_dequantize_functions and enabled
+        if enabled:
+            print(f"\nGGUF: Enabling Triton, supported quants: {tuple(dequant.triton_dequantize_functions)}")
+        return (passthrough_model.clone(),)
+
+
 NODE_CLASS_MAPPINGS = {
     "UnetLoaderGGUF": UnetLoaderGGUF,
     "CLIPLoaderGGUF": CLIPLoaderGGUF,
@@ -325,5 +353,6 @@ NODE_CLASS_MAPPINGS = {
     "TripleCLIPLoaderGGUF": TripleCLIPLoaderGGUF,
     "QuadrupleCLIPLoaderGGUF": QuadrupleCLIPLoaderGGUF,
     "UnetLoaderGGUFAdvanced": UnetLoaderGGUFAdvanced,
+    "GGUFTritonToggle": GGUFTritonToggle,
 }
 

--- a/nodes.py
+++ b/nodes.py
@@ -13,7 +13,7 @@ import comfy.model_patcher
 import comfy.model_management
 import folder_paths
 
-from .ops import GGMLOps, move_patch_to_device
+from .ops import GGMLOps, move_patch_to_device, LORA_CACHE
 from .loader import gguf_sd_loader, gguf_clip_loader
 from .dequant import is_quantized, is_torch_compatible, HAVE_TRITON, triton_dequantize_functions
 from . import dequant
@@ -150,8 +150,10 @@ class UnetLoaderGGUF:
 
     def load_unet(self, unet_name, dequant_dtype=None, patch_dtype=None, patch_on_device=None, optimize="none"):
         dequantize_function = dequantize_handlers = None
-        if optimize == "triton":
-            dequantize_handlers = dequant.dequantize_functions | dequant.triton_dequantize_functions
+        opt_set = frozenset(optimize.lower().strip().split("_")) if optimize != "none" and optimize else frozenset()
+        if "triton" in opt_set and dequant.dequant_triton is not None:
+            dq_triton = dequant.dequant_triton
+            dequantize_handlers = dequant.dequantize_functions | (dq_triton.dequantize_functions if "legacykernel" not in opt_set else dq_triton.dequantize_functions_legacy)
 
         if dequant_dtype == "default":
             dequant_dtype = None
@@ -166,7 +168,7 @@ class UnetLoaderGGUF:
             dequant_dtype = dequant_dtype,
             patch_dtype = patch_dtype,
             patch_on_device = patch_on_device,
-            optimize=optimize,
+            optimize=opt_set,
             dequantize_function = dequantize_function,
             dequantize_handlers = dequantize_handlers,
         )
@@ -196,7 +198,10 @@ class UnetLoaderGGUFAdvanced(UnetLoaderGGUF):
     @classmethod
     def INPUT_TYPES(s):
         unet_names = [x for x in folder_paths.get_filename_list("unet_gguf")]
-        pretty_triton_quants = ", ".join(k.name for k in triton_dequantize_functions)
+        pretty_triton_quants = ", ".join(
+            k.name if not v.use_vectorized else f"{k.name} (fused)"
+            for k, v in triton_dequantize_functions.items()
+        )
         return {
             "required": {
                 "unet_name": (unet_names,),
@@ -210,10 +215,10 @@ class UnetLoaderGGUFAdvanced(UnetLoaderGGUF):
                 ),
                 "patch_on_device": ("BOOLEAN", {"default": False}),
                 "optimize": (
-                    ("none", "triton"),
+                    ("none", "loracache", "triton", "triton_loracache", "triton_legacykernel", "triton_legacykernel_loracache"),
                     {
                         "default": "none",
-                        "tooltip": f"Triton status: {'available' if HAVE_TRITON else 'unavailable'}\nTriton kernels: {pretty_triton_quants}",
+                        "tooltip": f"Optimizations:\ntriton: Uses Triton with vectorized kernels, only has an effect if Triton is available.\nlegacykernel: Uses the old style Triton kernels. There shouldn't really be a difference in performance.\nloracache: Enables LoRA caching. WARNING: LoRAs are cached forever in a global cache which can only be cleared/refreshed with the GGUFClearLoRACache node. Memory will be retained and LoRA changes won't have an effect unless you use this node. When enabled, expect the first step to be relatively slow as LoRAs are cached. Additionally, this probably won't work with exotic LoRA types or scheduling LoRAs.\n\nTriton status: {'available' if HAVE_TRITON else 'unavailable'}\nTriton kernels: {pretty_triton_quants}",
                     },
                 ),
             }
@@ -342,6 +347,28 @@ class QuadrupleCLIPLoaderGGUF(CLIPLoaderGGUF):
         return (self.load_patcher(clip_paths, clip_type, self.load_data(clip_paths)),)
 
 
+class GGUFClearLoRACache:
+    FUNCTION = "go"
+    CATEGORY = "bootleg"
+    RETURN_TYPES =("MODEL",)
+    TITLE = "Clear LoRA cache (GGUF)"
+    DESCRIPTION = "Clears the global GGUF LoRA cache whenever it runs. Generally you would put it after your LoRA model patches so it runs when LoRAs change. LoRA caching can be enabled with the advanced loader and choosing an optimize mode with 'loracache' in it."
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "model": ("MODEL",),
+                "seq": ("INT", {"default": 0, "tooltip": "This parameter isn't used for anything. You can change it to force the node to run and clear the LoRA cache."}),
+            },
+        }
+
+    @classmethod
+    def go(cls, *, model: object, seq: int = 0) -> tuple[object]:
+        LORA_CACHE.clear()
+        return (model,)
+
+
 NODE_CLASS_MAPPINGS = {
     "UnetLoaderGGUF": UnetLoaderGGUF,
     "CLIPLoaderGGUF": CLIPLoaderGGUF,
@@ -349,5 +376,5 @@ NODE_CLASS_MAPPINGS = {
     "TripleCLIPLoaderGGUF": TripleCLIPLoaderGGUF,
     "QuadrupleCLIPLoaderGGUF": QuadrupleCLIPLoaderGGUF,
     "UnetLoaderGGUFAdvanced": UnetLoaderGGUFAdvanced,
+    "GGUFClearLoRACache": GGUFClearLoRACache,
 }
-

--- a/nodes.py
+++ b/nodes.py
@@ -15,7 +15,7 @@ import folder_paths
 
 from .ops import GGMLOps, move_patch_to_device
 from .loader import gguf_sd_loader, gguf_clip_loader
-from .dequant import is_quantized, is_torch_compatible
+from .dequant import is_quantized, is_torch_compatible, HAVE_TRITON, triton_dequantize_functions
 from . import dequant
 
 def update_folder_names_and_paths(key, targets=[]):
@@ -207,13 +207,26 @@ class UnetLoaderGGUFAdvanced(UnetLoaderGGUF):
     @classmethod
     def INPUT_TYPES(s):
         unet_names = [x for x in folder_paths.get_filename_list("unet_gguf")]
+        pretty_triton_quants = ", ".join(k.name for k in triton_dequantize_functions)
         return {
             "required": {
                 "unet_name": (unet_names,),
-                "dequant_dtype": (["default", "target", "float32", "float16", "bfloat16"], {"default": "default"}),
-                "patch_dtype": (["default", "target", "float32", "float16", "bfloat16"], {"default": "default"}),
+                "dequant_dtype": (
+                    ["default", "target", "float32", "float16", "bfloat16"],
+                    {"default": "default"},
+                ),
+                "patch_dtype": (
+                    ["default", "target", "float32", "float16", "bfloat16"],
+                    {"default": "default"},
+                ),
                 "patch_on_device": ("BOOLEAN", {"default": False}),
-                "optimize": (("none", "compile", "triton"), {"default": "none"}),
+                "optimize": (
+                    ("none", "compile", "triton"),
+                    {
+                        "default": "none",
+                        "tooltip": f"Triton status: {'available' if HAVE_TRITON else 'unavailable'}\nTriton kernels: {pretty_triton_quants}",
+                    },
+                ),
             }
         }
     TITLE = "Unet Loader (GGUF/Advanced)"
@@ -258,7 +271,7 @@ class CLIPLoaderGGUF:
             clip_type = clip_type,
             state_dicts = clip_data,
             model_options = {
-                "custom_operations": GGMLOps,
+                "custom_operations": GGMLOps(),
                 "initial_device": comfy.model_management.text_encoder_offload_device()
             },
             embedding_directory = folder_paths.get_folder_paths("embeddings"),

--- a/nodes.py
+++ b/nodes.py
@@ -150,18 +150,7 @@ class UnetLoaderGGUF:
 
     def load_unet(self, unet_name, dequant_dtype=None, patch_dtype=None, patch_on_device=None, optimize="none"):
         dequantize_function = dequantize_handlers = None
-        if optimize == "compile":
-            compile_opts={}
-            try:
-                dequantize_function = torch.compile(dequant.dequantize, **compile_opts)
-                dequantize_handlers = {
-                    k: torch.compile(v, **compile_opts)
-                    for k, v in dequant.dequantize_functions.items()
-                }
-            except Exception as exc:
-                dequantize_function = dequantize_handlers = None
-                print(f"GGUF: Failed to compile dequant functions: {exc}")
-        elif optimize == "triton":
+        if optimize == "triton":
             dequantize_handlers = dequant.dequantize_functions | dequant.triton_dequantize_functions
 
         if dequant_dtype == "default":
@@ -182,7 +171,7 @@ class UnetLoaderGGUF:
             dequantize_handlers = dequantize_handlers,
         )
         print(f"\nGGUF: Using config {config}")
-        ops = GGMLOps(ggufconfig=config)
+        ops = GGMLOps(gguf_config=config)
 
         # init model
         unet_path = folder_paths.get_full_path("unet", unet_name)
@@ -221,7 +210,7 @@ class UnetLoaderGGUFAdvanced(UnetLoaderGGUF):
                 ),
                 "patch_on_device": ("BOOLEAN", {"default": False}),
                 "optimize": (
-                    ("none", "compile", "triton"),
+                    ("none", "triton"),
                     {
                         "default": "none",
                         "tooltip": f"Triton status: {'available' if HAVE_TRITON else 'unavailable'}\nTriton kernels: {pretty_triton_quants}",

--- a/ops.py
+++ b/ops.py
@@ -153,7 +153,7 @@ class GGMLLayer(torch.nn.Module):
         if self.largest_layer:
             dequant_dtype = self.gguf_config.dequant_dtype
             shape = getattr(self.weight, "tensor_shape", self.weight.shape)
-            dtype = self.dequant_dtype if self.dequant_dtype and self.dequant_dtype != "target" else torch.float16
+            dtype = dequant_dtype if dequant_dtype and dequant_dtype != "target" else torch.float16
             temp = torch.empty(*shape, device=torch.device("meta"), dtype=dtype)
             destination[prefix + "temp.weight"] = temp
 

--- a/ops.py
+++ b/ops.py
@@ -1,4 +1,5 @@
 # (c) City96 || Apache-2.0 (apache.org/licenses/LICENSE-2.0)
+import contextlib
 import functools
 import logging
 import operator
@@ -198,15 +199,29 @@ class GGMLLayer(torch.nn.Module):
         if bias is not None:
             destination[prefix + "bias"] = self.get_weight(self.bias)
 
-    def get_weight(self, tensor, dtype):
+    def get_weight_patches(self, tensor, device):
+        # consolidate and load patches to GPU in async
+        patch_list = []
+        key = None
+        for patches, key in getattr(tensor, "patches", []):
+            patch_list += move_patch_to_device(patches, device)
+
+        return tuple(patch_list), key
+
+    def get_weight(
+        self, tensor, dtype, patches_tensor=None, apply_patches: bool = True
+    ):
         if tensor is None:
             return
 
-        # consolidate and load patches to GPU in async
-        patch_list = []
         device = tensor.device
-        for patches, key in getattr(tensor, "patches", []):
-            patch_list += move_patch_to_device(patches, device)
+        patch_list, key = (
+            self.get_weight_patches(
+                patches_tensor if patches_tensor is not None else tensor, device
+            )
+            if apply_patches
+            else ((), None)
+        )
 
         # dequantize tensor while patches load
         weight = dequantize_tensor(tensor, dtype, self.gguf_config)
@@ -215,19 +230,18 @@ class GGMLLayer(torch.nn.Module):
         if isinstance(weight, GGMLTensor):
             weight = torch.Tensor(weight)
 
-        patch_dtype = self.gguf_config.patch_dtype
+        if not patch_list:
+            return weight
 
         # apply patches
-        if len(patch_list) > 0:
-            if patch_dtype is None:
-                weight = comfy.lora.calculate_weight(patch_list, weight, key)
-            else:
-                # for testing, may degrade image quality
-                if patch_dtype == "target":
-                    patch_dtype = dtype
-                weight = comfy.lora.calculate_weight(
-                    patch_list, weight, key, patch_dtype
-                )
+        patch_dtype = self.gguf_config.patch_dtype
+        if patch_dtype is None:
+            weight = comfy.lora.calculate_weight(patch_list, weight, key)
+        else:
+            # for testing, may degrade image quality
+            if patch_dtype == "target":
+                patch_dtype = dtype
+            weight = comfy.lora.calculate_weight(patch_list, weight, key, patch_dtype)
         return weight
 
     @torch_compiler_disable()
@@ -240,19 +254,23 @@ class GGMLLayer(torch.nn.Module):
             if device is None:
                 device = input.device
 
-        bias = None
-        non_blocking = model_management.device_supports_non_blocking(device)
-        if self.bias is not None:
-            bias = self.get_weight(self.bias.to(device), dtype)
-            bias = comfy.ops.cast_to(
-                bias, bias_dtype, device, non_blocking=non_blocking, copy=False
+        ostream = None
+        try:
+            qweight, qbias, ostream = comfy.ops.cast_bias_weight(
+                self,
+                input=None,
+                device=device,
+                dtype=self.weight.dtype,
+                bias_dtype=None if self.bias is None else self.bias.dtype,
+                offloadable=True,
             )
-
-        weight = self.get_weight(self.weight.to(device), dtype)
-        weight = comfy.ops.cast_to(
-            weight, dtype, device, non_blocking=non_blocking, copy=False
-        )
-        return weight, bias
+            if qbias is not None:
+                bias = self.get_weight(qbias, dtype, patches_tensor=self.bias)
+            weight = self.get_weight(qweight, dtype, patches_tensor=self.weight)
+            return weight, bias
+        finally:
+            if ostream is not None:
+                comfy.ops.uncast_bias_weight(self, qweight, qbias, ostream)
 
     def forward_comfy_cast_weights(self, input, *args, **kwargs):
         if self.is_ggml_quantized():
@@ -393,7 +411,6 @@ class GGMLOps(comfy.ops.manual_cast):
             patches,
             weight_shape: tuple[int, ...],
             dequantize_weight: Callable[[torch.dtype], torch.Tensor],
-            non_blocking: bool = False,
             rank_threshold: float = 1e-05,
             max_rank: int = 256,
             decomp_iters: int = 2,
@@ -405,14 +422,12 @@ class GGMLOps(comfy.ops.manual_cast):
                 return None, None
 
             # print(f"\nFLAT PATCHES: {patches}")
-            # patch_hashes = tuple(hash_patch(p) for p in flat_patches)
             patch_hashes = None
             patch_ids = tuple(id(p) for p in flat_patches)
             patch_key = pk
 
             device, dtype = x.device, x.dtype
             cache_key = (id(self),)
-            # cache_key = (id(self), *patch_ids)
             orig_cache_item = cache_item = LORA_CACHE.get(cache_key)
             if cache_item and (
                 weight_shape != cache_item.weight_shape
@@ -586,57 +601,58 @@ class GGMLOps(comfy.ops.manual_cast):
             if weight is None or dequant.is_torch_compatible(weight):
                 return None
             qtype = getattr(weight, "tensor_type", None)
-            oshape = tuple(getattr(weight, "tensor_shape", weight.shape))
             qfun = self.gguf_config.dequantize_handlers.get(qtype)
-            bias = getattr(self, "bias", None)
-            non_blocking = model_management.device_supports_non_blocking(device)
-            # print(f"\nPATCH LEN: {len(patches)}")
-            weight = model_management.cast_to(
-                weight.data,
-                dtype=None,
-                device=device,
-                non_blocking=non_blocking,
-                copy=False,
-            )
-
-            def dequantize_weight(dtype=torch.float32) -> torch.Tensor:
-                return qfun(
-                    weight,
-                    dtype=dtype,
-                    block_size=qfun.block_size,
-                    type_size=qfun.type_size,
-                ).reshape(oshape)
-
-            if patches:
-                lora_result, patched_weight = self._get_lora(
-                    x=input,
-                    patches=patches,
-                    weight_shape=oshape,
-                    dequantize_weight=dequantize_weight,
-                    non_blocking=non_blocking,
-                )
-                lora_A, lora_B = (
-                    lora_result if lora_result is not None else (None, None)
-                )
-            else:
-                lora_A = lora_B = patched_weight = None
-            if self.bias is not None:
-                bias = self.get_weight(self.bias.to(device), dtype)
-                bias = model_management.cast_to(
-                    bias,
-                    dtype=dtype,
+            if not (hasattr(qfun, "block_size") and hasattr(qfun, "type_size")):
+                return None
+            oshape = tuple(getattr(weight, "tensor_shape", weight.shape))
+            ostream = qweight = qbias = None
+            try:
+                qweight, qbias, ostream = comfy.ops.cast_bias_weight(
+                    self,
+                    input=None,
                     device=device,
-                    non_blocking=non_blocking,
-                    copy=False,
-                ).data
-            if patched_weight is None:
-                patched_weight = dequantize_weight(input.dtype)
+                    dtype=self.weight.dtype,
+                    bias_dtype=None if self.bias is None else self.bias.dtype,
+                    offloadable=True,
+                )
+
+                def dequantize_weight(
+                    dtype=torch.float32, qweight=qweight
+                ) -> torch.Tensor:
+                    out = qfun(
+                        qweight,
+                        dtype=dtype,
+                        block_size=qfun.block_size,
+                        type_size=qfun.type_size,
+                    )
+                    return out.reshape(oshape)
+
+                if patches:
+                    lora_result, patched_weight = self._get_lora(
+                        x=input,
+                        patches=patches,
+                        weight_shape=oshape,
+                        dequantize_weight=dequantize_weight,
+                    )
+                    lora_A, lora_B = (
+                        lora_result if lora_result is not None else (None, None)
+                    )
+                else:
+                    lora_A = lora_B = patched_weight = None
+                if qbias is not None:
+                    bias = self.get_weight(qbias, dtype, patches_tensor=self.bias)
+                if patched_weight is None:
+                    patched_weight = dequantize_weight(input.dtype)
+            finally:
+                if ostream is not None:
+                    comfy.ops.uncast_bias_weight(self, qweight, qbias, ostream)
+            del qweight, qbias, ostream
+
             already_patched = lora_A is None or lora_B is None
             if not already_patched:
                 M = input.numel() // input.shape[-1]
                 K, N = self.in_features, self.out_features
                 use_activation = M <= ((N * K) / max(1, N + K))
-                # use_activation = False
                 if not use_activation:
                     patched_weight.addmm_(lora_B.T, lora_A.T, alpha=1.0, beta=1.0)
                     already_patched = True

--- a/ops.py
+++ b/ops.py
@@ -1,52 +1,67 @@
 # (c) City96 || Apache-2.0 (apache.org/licenses/LICENSE-2.0)
-from typing import Optional
-
-import gguf
-import torch
+import functools
 import logging
+import operator
+from typing import Callable, NamedTuple, Optional
 
-import comfy.ops
 import comfy.lora
-import comfy.model_management
+import comfy.model_management as model_management
+import comfy.ops
+import torch
+
+from . import dequant
 from .dequant import DEFAULT_CONFIG, GGUFConfig, dequantize_tensor, is_quantized
+
+try:
+    import comfy.weight_adapter as wadapter
+except (ImportError, ModuleNotFoundError):
+    wadapter = None
+
 
 def chained_hasattr(obj, chained_attr):
     probe = obj
-    for attr in chained_attr.split('.'):
+    for attr in chained_attr.split("."):
         if hasattr(probe, attr):
             probe = getattr(probe, attr)
         else:
             return False
     return True
 
+
 # A bakcward and forward compatible way to get `torch.compiler.disable`.
 def get_torch_compiler_disable_decorator():
     def dummy_decorator(*args, **kwargs):
         def noop(x):
             return x
+
         return noop
 
     from packaging import version
 
     if not chained_hasattr(torch, "compiler.disable"):
         logging.info("ComfyUI-GGUF: Torch too old for torch.compile - bypassing")
-        return dummy_decorator # torch too old
+        return dummy_decorator  # torch too old
     elif version.parse(torch.__version__) >= version.parse("2.8"):
         logging.info("ComfyUI-GGUF: Allowing full torch compile")
-        return dummy_decorator # torch compile works
+        return dummy_decorator  # torch compile works
     if chained_hasattr(torch, "_dynamo.config.nontraceable_tensor_subclasses"):
         logging.info("ComfyUI-GGUF: Allowing full torch compile (nightly)")
-        return dummy_decorator # torch compile works, nightly before 2.8 release
+        return dummy_decorator  # torch compile works, nightly before 2.8 release
     else:
-        logging.info("ComfyUI-GGUF: Partial torch compile only, consider updating pytorch")
+        logging.info(
+            "ComfyUI-GGUF: Partial torch compile only, consider updating pytorch"
+        )
         return torch.compiler.disable
 
+
 torch_compiler_disable = get_torch_compiler_disable_decorator()
+
 
 class GGMLTensor(torch.Tensor):
     """
     Main tensor-like class for storing quantized weights
     """
+
     def __init__(self, *args, tensor_type, tensor_shape, patches=[], **kwargs):
         super().__init__()
         self.tensor_type = tensor_type
@@ -80,10 +95,10 @@ class GGMLTensor(torch.Tensor):
         # Intel Arc fix, ref#50
         new_tensor = super().new_empty(size, *args, **kwargs)
         return GGMLTensor(
-                new_tensor,
-                tensor_type = getattr(self, "tensor_type", None),
-                tensor_shape = size,
-                patches = getattr(self, "patches", []).copy()
+            new_tensor,
+            tensor_type=getattr(self, "tensor_type", None),
+            tensor_shape=size,
+            patches=getattr(self, "patches", []).copy(),
         )
 
     @property
@@ -92,10 +107,12 @@ class GGMLTensor(torch.Tensor):
             self.tensor_shape = self.size()
         return self.tensor_shape
 
+
 class GGMLLayer(torch.nn.Module):
     """
     This (should) be responsible for de-quantizing on the fly
     """
+
     comfy_cast_weights = True
     largest_layer = False
 
@@ -107,18 +124,32 @@ class GGMLLayer(torch.nn.Module):
         return is_quantized(weight) or is_quantized(bias)
 
     def _load_from_state_dict(self, state_dict, prefix, *args, **kwargs):
-        weight, bias = state_dict.get(f"{prefix}weight"), state_dict.get(f"{prefix}bias")
+        weight, bias = (
+            state_dict.get(f"{prefix}weight"),
+            state_dict.get(f"{prefix}bias"),
+        )
         # NOTE: using modified load for linear due to not initializing on creation, see GGMLOps todo
-        if self.is_ggml_quantized(weight=weight, bias=bias) or isinstance(self, torch.nn.Linear):
+        if self.is_ggml_quantized(weight=weight, bias=bias) or isinstance(
+            self, torch.nn.Linear
+        ):
             return self.ggml_load_from_state_dict(state_dict, prefix, *args, **kwargs)
         # Not strictly required, but fixes embedding shape mismatch. Threshold set in loader.py
         if isinstance(self, torch.nn.Embedding) and self.weight.shape[0] >= (64 * 1024):
             return self.ggml_load_from_state_dict(state_dict, prefix, *args, **kwargs)
         return super()._load_from_state_dict(state_dict, prefix, *args, **kwargs)
 
-    def ggml_load_from_state_dict(self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs):
+    def ggml_load_from_state_dict(
+        self,
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+    ):
         prefix_len = len(prefix)
-        for k,v in state_dict.items():
+        for k, v in state_dict.items():
             if k[prefix_len:] == "weight":
                 self.weight = torch.nn.Parameter(v, requires_grad=False)
             elif k[prefix_len:] == "bias" and v is not None:
@@ -130,7 +161,7 @@ class GGMLLayer(torch.nn.Module):
         if self.weight is None and isinstance(self, torch.nn.Linear):
             v = torch.zeros(self.in_features, self.out_features)
             self.weight = torch.nn.Parameter(v, requires_grad=False)
-            missing_keys.append(prefix+"weight")
+            missing_keys.append(prefix + "weight")
 
         # for vram estimation (TODO: less fragile logic?)
         if getattr(self.weight, "is_largest_weight", False):
@@ -153,7 +184,11 @@ class GGMLLayer(torch.nn.Module):
         if self.largest_layer:
             dequant_dtype = self.gguf_config.dequant_dtype
             shape = getattr(self.weight, "tensor_shape", self.weight.shape)
-            dtype = dequant_dtype if dequant_dtype and dequant_dtype != "target" else torch.float16
+            dtype = (
+                dequant_dtype
+                if dequant_dtype and dequant_dtype != "target"
+                else torch.float16
+            )
             temp = torch.empty(*shape, device=torch.device("meta"), dtype=dtype)
             destination[prefix + "temp.weight"] = temp
 
@@ -164,37 +199,39 @@ class GGMLLayer(torch.nn.Module):
             destination[prefix + "bias"] = self.get_weight(self.bias)
 
     def get_weight(self, tensor, dtype):
-            if tensor is None:
-                return
+        if tensor is None:
+            return
 
-            # consolidate and load patches to GPU in async
-            patch_list = []
-            device = tensor.device
-            for patches, key in getattr(tensor, "patches", []):
-                patch_list += move_patch_to_device(patches, device)
+        # consolidate and load patches to GPU in async
+        patch_list = []
+        device = tensor.device
+        for patches, key in getattr(tensor, "patches", []):
+            patch_list += move_patch_to_device(patches, device)
 
-            # dequantize tensor while patches load
-            weight = dequantize_tensor(tensor, dtype, self.gguf_config)
+        # dequantize tensor while patches load
+        weight = dequantize_tensor(tensor, dtype, self.gguf_config)
 
-            # prevent propagating custom tensor class
-            if isinstance(weight, GGMLTensor):
-                weight = torch.Tensor(weight)
+        # prevent propagating custom tensor class
+        if isinstance(weight, GGMLTensor):
+            weight = torch.Tensor(weight)
 
-            patch_dtype = self.gguf_config.patch_dtype
+        patch_dtype = self.gguf_config.patch_dtype
 
-            # apply patches
-            if len(patch_list) > 0:
-                if patch_dtype is None:
-                    weight = comfy.lora.calculate_weight(patch_list, weight, key)
-                else:
-                    # for testing, may degrade image quality
-                    if patch_dtype == "target":
-                        patch_dtype = dtype
-                    weight = comfy.lora.calculate_weight(patch_list, weight, key, patch_dtype)
-            return weight
+        # apply patches
+        if len(patch_list) > 0:
+            if patch_dtype is None:
+                weight = comfy.lora.calculate_weight(patch_list, weight, key)
+            else:
+                # for testing, may degrade image quality
+                if patch_dtype == "target":
+                    patch_dtype = dtype
+                weight = comfy.lora.calculate_weight(
+                    patch_list, weight, key, patch_dtype
+                )
+        return weight
 
     @torch_compiler_disable()
-    def cast_bias_weight(s, input=None, dtype=None, device=None, bias_dtype=None):
+    def cast_bias_weight(self, input=None, dtype=None, device=None, bias_dtype=None):
         if input is not None:
             if dtype is None:
                 dtype = getattr(input, "dtype", torch.float32)
@@ -204,13 +241,17 @@ class GGMLLayer(torch.nn.Module):
                 device = input.device
 
         bias = None
-        non_blocking = comfy.model_management.device_supports_non_blocking(device)
-        if s.bias is not None:
-            bias = s.get_weight(s.bias.to(device), dtype)
-            bias = comfy.ops.cast_to(bias, bias_dtype, device, non_blocking=non_blocking, copy=False)
+        non_blocking = model_management.device_supports_non_blocking(device)
+        if self.bias is not None:
+            bias = self.get_weight(self.bias.to(device), dtype)
+            bias = comfy.ops.cast_to(
+                bias, bias_dtype, device, non_blocking=non_blocking, copy=False
+            )
 
-        weight = s.get_weight(s.weight.to(device), dtype)
-        weight = comfy.ops.cast_to(weight, dtype, device, non_blocking=non_blocking, copy=False)
+        weight = self.get_weight(self.weight.to(device), dtype)
+        weight = comfy.ops.cast_to(
+            weight, dtype, device, non_blocking=non_blocking, copy=False
+        )
         return weight, bias
 
     def forward_comfy_cast_weights(self, input, *args, **kwargs):
@@ -228,6 +269,88 @@ class GGMLLayer(torch.nn.Module):
         raise NotImplementedError
 
 
+def compress_lora_pair(
+    A_cat: torch.Tensor,
+    B_cat: torch.Tensor,
+    *,
+    max_rank: int = 256,
+    threshold: float = 1e-05,
+):
+    """
+    A_cat: shape (in_features, R_total)
+    B_cat: shape (R_total, out_features)
+    """
+    R_total = A_cat.shape[1]
+
+    # 1. QR Decomposition of A
+    # Q_A is (in_features, R_total), R_A is (R_total, R_total)
+    Q_A, R_A = torch.linalg.qr(A_cat)
+
+    # 2. QR Decomposition of B (transposed to work on columns)
+    # Q_B_T is (out_features, R_total), R_B_T is (R_total, R_total)
+    Q_B_T, R_B_T = torch.linalg.qr(B_cat.T)
+
+    # Re-transpose to get L_B and Q_B
+    L_B = R_B_T.T  # shape (R_total, R_total)
+    Q_B = Q_B_T.T  # shape (R_total, out_features)
+
+    # 3. Create the tiny core matrix!
+    # This matrix is strictly (R_total x R_total). E.g., 640 x 640.
+    core_matrix = R_A @ L_B
+
+    # 4. Run SVD on the tiny core matrix
+    U, S, Vh = torch.linalg.svd(core_matrix)
+
+    # 5. Prune the overlapping/useless ranks
+    # Keep ranks where the singular value is above the threshold, up to max_rank
+    rank = min((S > threshold).sum().item(), max_rank)
+
+    if rank == R_total:
+        # No overlap found! Return the originals to save math.
+        return A_cat, B_cat
+
+    # Slice to the compressed rank
+    U_k = U[:, :rank]
+    S_k = S[:rank]
+    Vh_k = Vh[:rank, :]
+
+    # 6. Reconstruct the new, pruned A and B matrices
+    # A_new = Q_A @ U_k @ diag(S_k)
+    A_new = Q_A @ (U_k * S_k[None, :])  # Broadcasting is faster than diag
+
+    # B_new = Vh_k @ Q_B
+    B_new = Vh_k @ Q_B
+
+    return A_new, B_new
+
+
+def hash_patch(patch) -> int:
+    if isinstance(patch, (list, tuple)):
+        return functools.reduce(operator.xor, (hash_patch(pi) for pi in patch))
+    if isinstance(patch, wadapter.WeightAdapterBase):
+        return hash_patch(patch.weights) ^ hash_patch(patch.loaded_keys)
+    if isinstance(patch, torch.Tensor):
+        return patch.hash_tensor().detach().cpu().item()
+    if isinstance(patch, (set, frozenset)):
+        return hash_patch(tuple(patch))
+    if isinstance(patch, dict):
+        return hash_patch(tuple(patch.items()))
+    return hash(patch) if getattr(patch, "__hash__", None) is not None else id(patch)
+
+
+class PatchCacheItem(NamedTuple):
+    layer_id: int
+    weight_shape: tuple[int, ...]
+    patch_ids: tuple[int, ...]
+    patch_hashes: tuple[int, ...]
+    lora_A: torch.Tensor | None
+    lora_B: torch.Tensor | None
+
+
+# Key: id of layer module.
+LORA_CACHE: dict[tuple[int, ...], PatchCacheItem] = {}
+
+
 class GGMLOps(comfy.ops.manual_cast):
     """
     Dequantize weights on the fly before doing the compute
@@ -235,7 +358,7 @@ class GGMLOps(comfy.ops.manual_cast):
 
     _MODULE_NAMES = ("Linear", "Conv2d", "Embedding", "LayerNorm", "GroupNorm")
 
-    def __init__(self, *args, gguf_config: Optional[GGUFConfig]=None, **kwargs):
+    def __init__(self, *args, gguf_config: Optional[GGUFConfig] = None, **kwargs):
         super().__init__(*args, **kwargs)
         linear_config = gguf_config or DEFAULT_CONFIG
         # Ignore patch_dtype and dequant_dtype for non-Linear layers.
@@ -244,11 +367,16 @@ class GGMLOps(comfy.ops.manual_cast):
         for module_name in self._MODULE_NAMES:
             module = getattr(self.__class__, module_name)
             curr_config = linear_config if module_name == "Linear" else other_config
-            setattr(self, module_name, type(module_name, (module,), {"gguf_config": curr_config}))
-
+            setattr(
+                self,
+                module_name,
+                type(module_name, (module,), {"gguf_config": curr_config}),
+            )
 
     class Linear(GGMLLayer, comfy.ops.manual_cast.Linear):
-        def __init__(self, in_features, out_features, bias=True, device=None, dtype=None):
+        def __init__(
+            self, in_features, out_features, bias=True, device=None, dtype=None
+        ):
             torch.nn.Module.__init__(self)
             # TODO: better workaround for reserved memory spike on windows
             # Issue is with `torch.empty` still reserving the full memory for the layer
@@ -258,7 +386,283 @@ class GGMLOps(comfy.ops.manual_cast):
             self.weight = None
             self.bias = None
 
+        def _get_lora(
+            self,
+            *,
+            x: torch.Tensor,
+            patches,
+            weight_shape: tuple[int, ...],
+            dequantize_weight: Callable[[torch.dtype], torch.Tensor],
+            non_blocking: bool = False,
+            rank_threshold: float = 1e-05,
+            max_rank: int = 256,
+            decomp_iters: int = 2,
+        ) -> tuple[tuple[torch.Tensor, torch.Tensor] | None, torch.Tensor | None]:
+            flat_patches = []
+            for p, pk in patches:
+                flat_patches += p
+            if not flat_patches:
+                return None, None
+
+            # print(f"\nFLAT PATCHES: {patches}")
+            # patch_hashes = tuple(hash_patch(p) for p in flat_patches)
+            patch_hashes = None
+            patch_ids = tuple(id(p) for p in flat_patches)
+            patch_key = pk
+
+            device, dtype = x.device, x.dtype
+            cache_key = (id(self),)
+            # cache_key = (id(self), *patch_ids)
+            orig_cache_item = cache_item = LORA_CACHE.get(cache_key)
+            if cache_item and (
+                weight_shape != cache_item.weight_shape
+                or (cache_item.lora_A is not None and cache_item.lora_A.dtype != dtype)
+            ):
+                cache_item = None
+            need_hashes = not cache_item or cache_item.patch_ids != patch_ids
+            if need_hashes:
+                patch_hashes = tuple(hash_patch(p) for p in flat_patches)
+            if cache_item and need_hashes:
+                if cache_item and cache_item.patch_hashes == patch_hashes:
+                    cache_item = cache_item._replace(patch_ids=patch_ids)
+                    LORA_CACHE[cache_key] = cache_item
+            if not cache_item and orig_cache_item:
+                print(
+                    f"\nLORA: INVALIDATING: key={patch_key}, id={cache_key}, weight={weight_shape}, expected weight={orig_cache_item.weight_shape}, patch_hashes {patch_hashes} != {orig_cache_item.patch_hashes}",
+                )
+                del LORA_CACHE[cache_key], orig_cache_item
+            if (
+                cache_item is not None
+                and cache_item.lora_A is not None
+                and cache_item.lora_B is not None
+            ):
+                lora_A, lora_B = cache_item.lora_A, cache_item.lora_B
+                if lora_A.device != device:
+                    lora_A = model_management.cast_to_device(
+                        lora_A,
+                        device,
+                        dtype,
+                        copy=True,
+                    )
+                if lora_B.device != device:
+                    lora_B = model_management.cast_to_device(
+                        lora_B,
+                        device,
+                        dtype,
+                        copy=True,
+                    )
+                return (lora_A.to(dtype=dtype), lora_B.to(dtype=dtype)), None
+
+            pure_lora = all(
+                # No offset
+                offset is None
+                # No special function handler
+                and fun is None
+                # Just LoRAs
+                and wadapter is not None
+                and isinstance(lo, wadapter.LoRAAdapter)
+                # With the expected number of weights
+                and len(lo.weights) == 6
+                # And no funny business like mid parts, reshaping or DoRA scales.
+                and tuple(lo.weights[-3:]) == (None, None, None)
+                for _strength, lo, _strength_model, offset, fun, *_rest in flat_patches
+            )
+            skip_decomp = cache_item is not None
+            patch_dtype = self.gguf_config.patch_dtype
+            eff_patch_dtype = (
+                (x.dtype if patch_dtype == "target" else patch_dtype)
+                if skip_decomp or pure_lora
+                else torch.float32
+            )
+            patch_list = []
+            for ppair in patches:
+                patch_list += move_patch_to_device(
+                    ppair[0], device=device, dtype=eff_patch_dtype
+                )
+
+            if skip_decomp or not pure_lora:
+                dq_weight = dequantize_weight(eff_patch_dtype)
+                # 1. Trick ComfyUI into giving us the dense delta
+                patched_weight = comfy.lora.calculate_weight(
+                    patch_list,
+                    dq_weight.clone(),
+                    patch_key,
+                    eff_patch_dtype,
+                )
+            if skip_decomp:
+                return None, patched_weight.to(dtype=x.dtype)
+            if pure_lora:
+                stack_a = []
+                stack_b = []
+                for strength, lo, *_rest in patch_list:
+                    lb, la, alpha = lo.weights[:3]
+                    la = la.to(dtype=torch.float32, copy=False)
+                    lb = lb.to(dtype=torch.float32, copy=False)
+                    rank = la.shape[0]
+                    eff_strength = strength * getattr(lo, "multiplier", 1.0)
+                    if alpha is not None:
+                        eff_strength *= alpha / rank
+                    if eff_strength == 0:
+                        continue
+                    if eff_strength != 1.0:
+                        la = la * eff_strength
+                    stack_a.append(la.T)
+                    stack_b.append(lb.T)
+                n_loras = len(stack_a)
+                lora_A = torch.cat(stack_a, dim=1)
+                lora_B = torch.cat(stack_b, dim=0)
+                print(
+                    f"\nSIMPLE PATH: Initial shapes: a={lora_A.shape}, b={lora_B.shape}"
+                )
+                del stack_a, stack_b, patch_list
+                if n_loras > 1:
+                    lora_A, lora_B = compress_lora_pair(
+                        lora_A,
+                        lora_B,
+                        max_rank=max_rank,
+                        threshold=rank_threshold,
+                    )
+                    print(
+                        f"SIMPLE PATH: Compressed shapes: a={lora_A.shape}, b={lora_B.shape}"
+                    )
+                lora_A = lora_A.to(dtype=dtype).contiguous()
+                lora_B = lora_B.to(dtype=dtype).contiguous()
+                LORA_CACHE[cache_key] = PatchCacheItem(
+                    layer_id=cache_key[0],
+                    weight_shape=weight_shape,
+                    patch_ids=patch_ids,
+                    patch_hashes=patch_hashes,
+                    lora_A=lora_A.to(device="cpu"),
+                    lora_B=lora_B.to(device="cpu"),
+                )
+                return (lora_A, lora_B), None
+
+            dense_delta = patched_weight - dq_weight
+            del dq_weight
+
+            # 2. FAST SVD: Only compute the top singular values!
+            # Note: svd_lowrank returns V directly (shape: in_features, q) instead of V^T
+            max_expected_rank = min(max_rank, *weight_shape)
+            U, S, V = torch.svd_lowrank(
+                dense_delta, q=max_expected_rank, niter=decomp_iters
+            )
+
+            rank = (S > rank_threshold).sum().item()
+
+            if rank == max_expected_rank:
+                print(
+                    f"[{patch_key}] Warning: LoRA rank hit max limit ({max_expected_rank}). Some detail may be lost."
+                )
+
+            if rank == 0:
+                print(f"LORA: patch len={len(patch_ids)}, rank=0. Skipping.")
+                lora_A, lora_B = None, None
+            else:
+                # V is already (in_features, q), so we just slice it!
+                lora_A = V[:, :rank].to(dtype).contiguous()
+
+                # U is (out_features, q). Multiply by S and transpose to (rank, out_features)
+                lora_B = U[:, :rank].mul_(S[:rank]).T.to(dtype).contiguous()
+                print(
+                    f"\nLORA: patch len={len(patch_list)}, input shape={x.shape}, weight shape={weight_shape}, rank={rank} ({max_expected_rank}), A shape={lora_A.shape}, B shape={lora_B.shape}"
+                )
+
+            LORA_CACHE[cache_key] = PatchCacheItem(
+                layer_id=cache_key[0],
+                weight_shape=weight_shape,
+                patch_ids=patch_ids,
+                patch_hashes=patch_hashes,
+                lora_A=lora_A.to(device="cpu"),
+                lora_B=lora_B.to(device="cpu"),
+            )
+            return None, patched_weight.to(dtype=x.dtype)
+
+        def forward_lora_cache(self, input: torch.Tensor) -> torch.Tensor | None:
+            if "loracache" not in self.gguf_config.optimize:
+                return None
+            dtype, device = input.dtype, input.device
+            weight = getattr(self, "weight", None)
+            patches = getattr(weight, "patches", ())
+            if weight is None or dequant.is_torch_compatible(weight):
+                return None
+            qtype = getattr(weight, "tensor_type", None)
+            oshape = tuple(getattr(weight, "tensor_shape", weight.shape))
+            qfun = self.gguf_config.dequantize_handlers.get(qtype)
+            bias = getattr(self, "bias", None)
+            non_blocking = model_management.device_supports_non_blocking(device)
+            # print(f"\nPATCH LEN: {len(patches)}")
+            weight = model_management.cast_to(
+                weight.data,
+                dtype=None,
+                device=device,
+                non_blocking=non_blocking,
+                copy=False,
+            )
+
+            def dequantize_weight(dtype=torch.float32) -> torch.Tensor:
+                return qfun(
+                    weight,
+                    dtype=dtype,
+                    block_size=qfun.block_size,
+                    type_size=qfun.type_size,
+                ).reshape(oshape)
+
+            if patches:
+                lora_result, patched_weight = self._get_lora(
+                    x=input,
+                    patches=patches,
+                    weight_shape=oshape,
+                    dequantize_weight=dequantize_weight,
+                    non_blocking=non_blocking,
+                )
+                lora_A, lora_B = (
+                    lora_result if lora_result is not None else (None, None)
+                )
+            else:
+                lora_A = lora_B = patched_weight = None
+            if self.bias is not None:
+                bias = self.get_weight(self.bias.to(device), dtype)
+                bias = model_management.cast_to(
+                    bias,
+                    dtype=dtype,
+                    device=device,
+                    non_blocking=non_blocking,
+                    copy=False,
+                ).data
+            if patched_weight is None:
+                patched_weight = dequantize_weight(input.dtype)
+            already_patched = lora_A is None or lora_B is None
+            if not already_patched:
+                M = input.numel() // input.shape[-1]
+                K, N = self.in_features, self.out_features
+                use_activation = M <= ((N * K) / max(1, N + K))
+                # use_activation = False
+                if not use_activation:
+                    patched_weight.addmm_(lora_B.T, lora_A.T, alpha=1.0, beta=1.0)
+                    already_patched = True
+            result = torch.nn.functional.linear(input, patched_weight, bias)
+            if already_patched or lora_A is None or lora_B is None:
+                return result
+            # Activation patching code path.
+            input_2d = input.view(-1, K)
+            result_2d = result.view(-1, N)
+
+            result_2d.addmm_(
+                # X @ A -> shape (M, rank)
+                input_2d @ lora_A,
+                lora_B,
+                alpha=1.0,
+                beta=1.0,
+            )
+
+            # 4. Reshape back to original dimensions
+            return result_2d.view(*input.shape[:-1], N)
+
         def forward_ggml_cast_weights(self, input):
+            comfy.ops.run_every_op()
+            result = self.forward_lora_cache(input)
+            if result is not None:
+                return result
             weight, bias = self.cast_bias_weight(input)
             return torch.nn.functional.linear(input, weight, bias)
 
@@ -270,11 +674,22 @@ class GGMLOps(comfy.ops.manual_cast):
     class Embedding(GGMLLayer, comfy.ops.manual_cast.Embedding):
         def forward_ggml_cast_weights(self, input, out_dtype=None):
             output_dtype = out_dtype
-            if self.weight.dtype == torch.float16 or self.weight.dtype == torch.bfloat16:
+            if (
+                self.weight.dtype == torch.float16
+                or self.weight.dtype == torch.bfloat16
+            ):
                 out_dtype = None
-            weight, _bias = self.cast_bias_weight(self, device=input.device, dtype=out_dtype)
+            weight, _bias = self.cast_bias_weight(
+                self, device=input.device, dtype=out_dtype
+            )
             return torch.nn.functional.embedding(
-                input, weight, self.padding_idx, self.max_norm, self.norm_type, self.scale_grad_by_freq, self.sparse
+                input,
+                weight,
+                self.padding_idx,
+                self.max_norm,
+                self.norm_type,
+                self.scale_grad_by_freq,
+                self.sparse,
             ).to(dtype=output_dtype)
 
     class LayerNorm(GGMLLayer, comfy.ops.manual_cast.LayerNorm):
@@ -282,19 +697,40 @@ class GGMLOps(comfy.ops.manual_cast):
             if self.weight is None:
                 return super().forward_comfy_cast_weights(input)
             weight, bias = self.cast_bias_weight(input)
-            return torch.nn.functional.layer_norm(input, self.normalized_shape, weight, bias, self.eps)
+            return torch.nn.functional.layer_norm(
+                input, self.normalized_shape, weight, bias, self.eps
+            )
 
     class GroupNorm(GGMLLayer, comfy.ops.manual_cast.GroupNorm):
         def forward_ggml_cast_weights(self, input):
             weight, bias = self.cast_bias_weight(input)
-            return torch.nn.functional.group_norm(input, self.num_groups, weight, bias, self.eps)
+            return torch.nn.functional.group_norm(
+                input, self.num_groups, weight, bias, self.eps
+            )
 
-def move_patch_to_device(item, device):
-    if isinstance(item, torch.Tensor):
-        return item.to(device, non_blocking=True)
-    elif isinstance(item, tuple):
-        return tuple(move_patch_to_device(x, device) for x in item)
-    elif isinstance(item, list):
-        return [move_patch_to_device(x, device) for x in item]
-    else:
+
+def move_patch_to_device(item, device, *, dtype=None):
+    if device is None:
         return item
+    if isinstance(item, torch.Tensor):
+        return model_management.cast_to_device(item, device, dtype, copy=True)
+    if isinstance(item, (tuple, list)):
+        return item.__class__(
+            move_patch_to_device(seqitem, device, dtype=dtype) for seqitem in item
+        )
+    if (
+        wadapter is not None
+        and isinstance(item, wadapter.WeightAdapterBase)
+        and hasattr(item, "loaded_keys")
+        and isinstance(getattr(item, "weights", None), (tuple, list))
+    ):
+        return item.__class__(
+            item.loaded_keys,
+            item.weights.__class__(
+                wi
+                if not isinstance(wi, torch.Tensor)
+                else model_management.cast_to_device(wi, device, dtype, copy=True)
+                for wi in item.weights
+            ),
+        )
+    return item

--- a/ops.py
+++ b/ops.py
@@ -1,4 +1,6 @@
 # (c) City96 || Apache-2.0 (apache.org/licenses/LICENSE-2.0)
+from typing import Optional
+
 import gguf
 import torch
 import logging
@@ -6,7 +8,7 @@ import logging
 import comfy.ops
 import comfy.lora
 import comfy.model_management
-from .dequant import dequantize_tensor, is_quantized
+from .dequant import DEFAULT_CONFIG, GGUFConfig, dequantize_tensor, is_quantized
 
 def chained_hasattr(obj, chained_attr):
     probe = obj
@@ -95,10 +97,7 @@ class GGMLLayer(torch.nn.Module):
     This (should) be responsible for de-quantizing on the fly
     """
     comfy_cast_weights = True
-    dequant_dtype = None
-    patch_dtype = None
     largest_layer = False
-    torch_compatible_tensor_types = {None, gguf.GGMLQuantizationType.F32, gguf.GGMLQuantizationType.F16}
 
     def is_ggml_quantized(self, *, weight=None, bias=None):
         if weight is None:
@@ -152,6 +151,7 @@ class GGMLLayer(torch.nn.Module):
 
         # Take into account space required for dequantizing the largest tensor
         if self.largest_layer:
+            dequant_dtype = self.ggufconfig.dequant_dtype
             shape = getattr(self.weight, "tensor_shape", self.weight.shape)
             dtype = self.dequant_dtype if self.dequant_dtype and self.dequant_dtype != "target" else torch.float16
             temp = torch.empty(*shape, device=torch.device("meta"), dtype=dtype)
@@ -166,29 +166,34 @@ class GGMLLayer(torch.nn.Module):
     def get_weight(self, tensor, dtype):
         if tensor is None:
             return
+        patch_dtype = self.ggufconfig.patch_dtype
 
         # consolidate and load patches to GPU in async
         patch_list = []
         device = tensor.device
+
+        key = patches = None
         for patches, key in getattr(tensor, "patches", []):
             patch_list += move_patch_to_device(patches, device)
 
         # dequantize tensor while patches load
-        weight = dequantize_tensor(tensor, dtype, self.dequant_dtype)
+        weight = dequantize_tensor(tensor, dtype, self.ggufconfig)
 
         # prevent propagating custom tensor class
         if isinstance(weight, GGMLTensor):
             weight = torch.Tensor(weight)
 
+        if key is None:
+            # Patch list was empty.
+            return weight
+
         # apply patches
-        if len(patch_list) > 0:
-            if self.patch_dtype is None:
-                weight = comfy.lora.calculate_weight(patch_list, weight, key)
-            else:
-                # for testing, may degrade image quality
-                patch_dtype = dtype if self.patch_dtype == "target" else self.patch_dtype
-                weight = comfy.lora.calculate_weight(patch_list, weight, key, patch_dtype)
-        return weight
+        if patch_dtype is None:
+            return comfy.lora.calculate_weight(patch_list, weight, key)
+
+        # for testing, may degrade image quality
+        patch_dtype = dtype if patch_dtype == "target" else patch_dtype
+        return comfy.lora.calculate_weight(patch_list, weight, key, patch_dtype)
 
     @torch_compiler_disable()
     def cast_bias_weight(s, input=None, dtype=None, device=None, bias_dtype=None):
@@ -224,10 +229,26 @@ class GGMLLayer(torch.nn.Module):
     def forward_ggml_cast_weights(self, input):
         raise NotImplementedError
 
+
 class GGMLOps(comfy.ops.manual_cast):
     """
     Dequantize weights on the fly before doing the compute
     """
+
+    _MODULE_NAMES = ("Linear", "Conv2d", "Embedding", "LayerNorm", "GroupNorm")
+
+    def __init__(self, *args, ggufconfig: Optional[GGUFConfig]=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        linear_config = ggufconfig or DEFAULT_CONFIG
+        # Ignore patch_dtype and dequant_dtype for non-Linear layers.
+        other_config = linear_config._replace(patch_dtype=None, dequant_dtype=None)
+        self.ggufconfig = linear_config
+        for module_name in self._MODULE_NAMES:
+            module = getattr(self.__class__, module_name)
+            curr_config = linear_config if module_name == "Linear" else other_config
+            setattr(self, module_name, type(module_name, (module,), {"ggufconfig": curr_config}))
+
+
     class Linear(GGMLLayer, comfy.ops.manual_cast.Linear):
         def __init__(self, in_features, out_features, bias=True, device=None, dtype=None):
             torch.nn.Module.__init__(self)

--- a/ops.py
+++ b/ops.py
@@ -255,15 +255,29 @@ class GGMLLayer(torch.nn.Module):
                 device = input.device
 
         ostream = None
+        hack_w = not dequant.is_torch_compatible(self.weight)
+        hack_b = not (self.bias is None or dequant.is_torch_compatible(self.bias))
+        if hack_w:
+            wf = self.weight_function
+            self.weight_function = []
+        if hack_b:
+            bf = self.bias_function
+            self.bias_function = []
         try:
-            qweight, qbias, ostream = comfy.ops.cast_bias_weight(
-                self,
-                input=None,
-                device=device,
-                dtype=self.weight.dtype,
-                bias_dtype=None if self.bias is None else self.bias.dtype,
-                offloadable=True,
-            )
+            try:
+                qweight, qbias, ostream = comfy.ops.cast_bias_weight(
+                    self,
+                    input=None,
+                    device=device,
+                    dtype=self.weight.dtype,
+                    bias_dtype=None if self.bias is None else self.bias.dtype,
+                    offloadable=True,
+                )
+            finally:
+                if hack_w:
+                    self.weight_function = wf
+                if hack_b:
+                    self.bias_function = bf
             if qbias is not None:
                 bias = self.get_weight(qbias, dtype, patches_tensor=self.bias)
             weight = self.get_weight(qweight, dtype, patches_tensor=self.weight)
@@ -606,15 +620,22 @@ class GGMLOps(comfy.ops.manual_cast):
                 return None
             oshape = tuple(getattr(weight, "tensor_shape", weight.shape))
             ostream = qweight = qbias = None
+            wf, bf = self.weight_function, self.bias_function
+            self.weight_function = []
+            self.bias_function = []
             try:
-                qweight, qbias, ostream = comfy.ops.cast_bias_weight(
-                    self,
-                    input=None,
-                    device=device,
-                    dtype=self.weight.dtype,
-                    bias_dtype=None if self.bias is None else self.bias.dtype,
-                    offloadable=True,
-                )
+                try:
+                    qweight, qbias, ostream = comfy.ops.cast_bias_weight(
+                        self,
+                        input=None,
+                        device=device,
+                        dtype=self.weight.dtype,
+                        bias_dtype=None if self.bias is None else self.bias.dtype,
+                        offloadable=True,
+                    )
+                finally:
+                    self.weight_function = wf
+                    self.bias_function = bf
 
                 def dequantize_weight(
                     dtype=torch.float32, qweight=qweight

--- a/ops.py
+++ b/ops.py
@@ -151,7 +151,7 @@ class GGMLLayer(torch.nn.Module):
 
         # Take into account space required for dequantizing the largest tensor
         if self.largest_layer:
-            dequant_dtype = self.ggufconfig.dequant_dtype
+            dequant_dtype = self.gguf_config.dequant_dtype
             shape = getattr(self.weight, "tensor_shape", self.weight.shape)
             dtype = self.dequant_dtype if self.dequant_dtype and self.dequant_dtype != "target" else torch.float16
             temp = torch.empty(*shape, device=torch.device("meta"), dtype=dtype)
@@ -164,36 +164,34 @@ class GGMLLayer(torch.nn.Module):
             destination[prefix + "bias"] = self.get_weight(self.bias)
 
     def get_weight(self, tensor, dtype):
-        if tensor is None:
-            return
-        patch_dtype = self.ggufconfig.patch_dtype
+            if tensor is None:
+                return
 
-        # consolidate and load patches to GPU in async
-        patch_list = []
-        device = tensor.device
+            # consolidate and load patches to GPU in async
+            patch_list = []
+            device = tensor.device
+            for patches, key in getattr(tensor, "patches", []):
+                patch_list += move_patch_to_device(patches, device)
 
-        key = patches = None
-        for patches, key in getattr(tensor, "patches", []):
-            patch_list += move_patch_to_device(patches, device)
+            # dequantize tensor while patches load
+            weight = dequantize_tensor(tensor, dtype, self.gguf_config)
 
-        # dequantize tensor while patches load
-        weight = dequantize_tensor(tensor, dtype, self.ggufconfig)
+            # prevent propagating custom tensor class
+            if isinstance(weight, GGMLTensor):
+                weight = torch.Tensor(weight)
 
-        # prevent propagating custom tensor class
-        if isinstance(weight, GGMLTensor):
-            weight = torch.Tensor(weight)
+            patch_dtype = self.gguf_config.patch_dtype
 
-        if key is None:
-            # Patch list was empty.
+            # apply patches
+            if len(patch_list) > 0:
+                if patch_dtype is None:
+                    weight = comfy.lora.calculate_weight(patch_list, weight, key)
+                else:
+                    # for testing, may degrade image quality
+                    if patch_dtype == "target":
+                        patch_dtype = dtype
+                    weight = comfy.lora.calculate_weight(patch_list, weight, key, patch_dtype)
             return weight
-
-        # apply patches
-        if patch_dtype is None:
-            return comfy.lora.calculate_weight(patch_list, weight, key)
-
-        # for testing, may degrade image quality
-        patch_dtype = dtype if patch_dtype == "target" else patch_dtype
-        return comfy.lora.calculate_weight(patch_list, weight, key, patch_dtype)
 
     @torch_compiler_disable()
     def cast_bias_weight(s, input=None, dtype=None, device=None, bias_dtype=None):
@@ -237,16 +235,16 @@ class GGMLOps(comfy.ops.manual_cast):
 
     _MODULE_NAMES = ("Linear", "Conv2d", "Embedding", "LayerNorm", "GroupNorm")
 
-    def __init__(self, *args, ggufconfig: Optional[GGUFConfig]=None, **kwargs):
+    def __init__(self, *args, gguf_config: Optional[GGUFConfig]=None, **kwargs):
         super().__init__(*args, **kwargs)
-        linear_config = ggufconfig or DEFAULT_CONFIG
+        linear_config = gguf_config or DEFAULT_CONFIG
         # Ignore patch_dtype and dequant_dtype for non-Linear layers.
         other_config = linear_config._replace(patch_dtype=None, dequant_dtype=None)
-        self.ggufconfig = linear_config
+        self.gguf_config = linear_config
         for module_name in self._MODULE_NAMES:
             module = getattr(self.__class__, module_name)
             curr_config = linear_config if module_name == "Linear" else other_config
-            setattr(self, module_name, type(module_name, (module,), {"ggufconfig": curr_config}))
+            setattr(self, module_name, type(module_name, (module,), {"gguf_config": curr_config}))
 
 
     class Linear(GGMLLayer, comfy.ops.manual_cast.Linear):


### PR DESCRIPTION
Continuation of #331. Sorry for making a new pull, I couldn't reopen the existing one since it had been force pushed.

Wrapping the existing dequant functions with `torch.compile` in my benchmark tool brought the results to parity with Triton: https://gist.github.com/blepping/963459b244a4140b081cebdec24c56b2

However, I was not able to replicate that in the real world so the Triton kernels are back!

This includes a generic approach to pass configuration parameters around, including overriding the dequant functions (potentially with compiled or Triton versions). There is an `optimize` parameter in the advanced loader that lets you choose between `none`, `compile` and `triton`. Enabling Triton for me is noticeably faster, using `torch.compile` is actually slower than nothing.

This also fixes an issue with the existing approach to setting configuration like `dequant_dtype`:

```python
        ops = GGMLOps()

        if dequant_dtype in ("default", None):
            ops.Linear.dequant_dtype = None
        elif dequant_dtype in ["target"]:
            ops.Linear.dequant_dtype = dequant_dtype
        else:
            ops.Linear.dequant_dtype = getattr(torch, dequant_dtype)
```

This is not kosher because while `ops` is an instance of `GGMLOps`, attributes like `ops.Linear` are **not** instance specific, so setting it here will change that attribute in the global class. This means if there are multiple loaders with different settings, you will get the configuration of whatever loader overwrote that value last.