### PR TITLE
fix: add clip architecture to supported text models

### DIFF
--- a/loader.py
+++ b/loader.py
@@ -10,7 +10,7 @@ from .ops import GGMLTensor
 from .dequant import is_quantized, dequantize_tensor
 
 IMG_ARCH_LIST = {"flux", "sd1", "sdxl", "sd3", "aura", "hidream", "cosmos", "ltxv", "hyvid", "wan", "lumina2", "qwen_image"}
-TXT_ARCH_LIST = {"t5", "t5encoder", "llama", "qwen2vl"}
+TXT_ARCH_LIST = {"t5", "t5encoder", "llama", "qwen2vl", "clip"}
 VIS_TYPE_LIST = {"clip-vision"}
 
 def get_orig_shape(reader, tensor_name):
@@ -351,3 +351,4 @@ def gguf_clip_loader(path):
     else:
         pass
     return sd
+


### PR DESCRIPTION
Quick fix to allow loading text model GGUFs as clip, like Qwen 2.5 VL. 

```
  File "ComfyUI\custom_nodes\ComfyUI-GGUF\loader.py", line 89, in gguf_sd_loader
    raise ValueError(f"Unexpected text model architecture type in GGUF file: {arch_str!r}")
ValueError: Unexpected text model architecture type in GGUF file: 'clip'
```