### PR TITLE
add default named_modules_to_munmap variable

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -126,6 +126,7 @@ class GGUFModelPatcher(comfy.model_patcher.ModelPatcher):
         self.__class__ = src_cls
         # GGUF specific clone values below
         n.patch_on_device = getattr(self, "patch_on_device", False)
+        n.mmap_released = getattr(self, "mmap_released", False)
         if src_cls != GGUFModelPatcher:
             n.size = 0 # force recalc
         return n


### PR DESCRIPTION
Default this to handle to case of cloning a GGUFModelPatcher which then expects it to exist on the clone.

I could never reproduce this condition, however 4 users have the error. This error path is very sensitive to VRAM condtions and workflow and I never got the details so its a bit of a guess.

But from a code point of view, its the right thing anyway