### PR TITLE
Update lcpp.patch to fix & Add Support of HunyuanVideo 1.5 GGUF model

### DIFF
--- a/tools/lcpp.patch
+++ b/tools/lcpp.patch
@@ -1,5 +1,5 @@
 diff --git a/ggml/include/ggml.h b/ggml/include/ggml.h
-index de3c706f..0267c1fa 100644
+index de3c706fc..0267c1faa 100644
 --- a/ggml/include/ggml.h
 +++ b/ggml/include/ggml.h
 @@ -223,7 +223,7 @@
@@ -20,7 +20,7 @@ index de3c706f..0267c1fa 100644
      GGML_API void gguf_set_tensor_data(struct gguf_context * ctx, const char * name, const void * data, size_t size);
  
 diff --git a/ggml/src/ggml.c b/ggml/src/ggml.c
-index b16c462f..6d1568f1 100644
+index b16c462fa..6d1568f1b 100644
 --- a/ggml/src/ggml.c
 +++ b/ggml/src/ggml.c
 @@ -22960,6 +22960,14 @@ void gguf_add_tensor(
@@ -39,7 +39,7 @@ index b16c462f..6d1568f1 100644
      const int idx = gguf_find_tensor(ctx, name);
      if (idx < 0) {
 diff --git a/src/llama.cpp b/src/llama.cpp
-index 24e1f1f0..25db4c69 100644
+index 24e1f1f01..96523322b 100644
 --- a/src/llama.cpp
 +++ b/src/llama.cpp
 @@ -205,6 +205,17 @@ enum llm_arch {
@@ -320,7 +320,7 @@ index 24e1f1f0..25db4c69 100644
      }
  
      // Set split info if needed
-@@ -18647,6 +18874,110 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
+@@ -18647,6 +18874,111 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
          // do not quantize relative position bias (T5)
          quantize &= name.find("attn_rel_b.weight") == std::string::npos;
  
@@ -385,6 +385,7 @@ index 24e1f1f0..25db4c69 100644
 +            quantize &= name.find("vector_in.") == std::string::npos;
 +            quantize &= name.find("guidance_in.") == std::string::npos;
 +            quantize &= name.find("final_layer.") == std::string::npos;
++            quantize &= name != "cond_type_embedding.weight";
 +        }
 +        if (model.arch == LLM_ARCH_WAN) {
 +            image_model = true;
@@ -431,7 +432,7 @@ index 24e1f1f0..25db4c69 100644
          enum ggml_type new_type;
          void * new_data;
          size_t new_size;
-@@ -18655,6 +18986,9 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
+@@ -18655,6 +18987,9 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
              new_type = default_type;
  
              // get more optimal quantization type based on the tensor shape, layer, etc.
@@ -441,7 +442,7 @@ index 24e1f1f0..25db4c69 100644
              if (!params->pure && ggml_is_quantized(default_type)) {
                  new_type = llama_tensor_get_type(qs, new_type, tensor, ftype);
              }
-@@ -18664,6 +18998,7 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
+@@ -18664,6 +18999,7 @@ static void llama_model_quantize_internal(const std::string & fname_inp, const s
              if (params->output_tensor_type < GGML_TYPE_COUNT && strcmp(tensor->name, "output.weight") == 0) {
                  new_type = params->output_tensor_type;
              }


### PR DESCRIPTION
This patch prevents quantization of the `cond_type_embedding.weight` tensor, which causes a dimension mismatch when quantizing HunyuanVideo 1.5 to GGUF.


Error summary:
"cond_type_embedding.weight" model shape [3, 2048] does not match checkpoint shape [3, 2176].

Fix:
Exclude `cond_type_embedding.weight` from quantization so it stays in FP16, while all other layers are quantized normally.

[hunyuanvideo1.5 gguf](https://huggingface.co/jayn7/HunyuanVideo-1.5_I2V_720p-GGUF)