### PR TITLE
README update save path from /unet to /diffusion_models

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ On MacOS sequoia, torch 2.4.1 seems to be required, as 2.6.X nightly versions ca
 
 ## Usage
 
-Simply use the GGUF Unet loader found under the `bootleg` category. Place the .gguf model files in your `ComfyUI/models/unet` folder.
+Simply use the GGUF Unet loader found under the `bootleg` category. Place the .gguf model files in your `ComfyUI/models/diffusion_models` (Full diffusion models (UNet-only GGUFs)) folder or `ComfyUI/models/checkpoints` (Checkpoint-style GGUFs (UNet + text encoder combined)).
 
 LoRA loading is experimental but it should work with just the built-in LoRA loader node(s).
 


### PR DESCRIPTION
Comfyui-gguf doesn't have a unet loader anymore, so I think this is the correct place to put the .gguf files