### PR TITLE
Accept size-one ndarrays of any dimension from gguf reader

### DIFF
--- a/loader.py
+++ b/loader.py
@@ -33,7 +33,7 @@ def get_field(reader, field_name, field_type):
             raise TypeError(f"Bad type for GGUF {field_name} key: expected string, got {field.types!r}")
         return str(field.parts[field.data[-1]], encoding="utf-8")
     elif field_type in [int, float, bool]:
-        return field_type(field.parts[field.data[-1]])
+        return field_type(field.parts[field.data[-1]].item())
     else:
         raise TypeError(f"Unknown field type {field_type}")
 
@@ -404,3 +404,4 @@ def gguf_clip_loader(path):
     else:
         pass
     return sd
+


### PR DESCRIPTION
Sometimes gguf will return size-one one-dimensional memmaps for scalar values. I'm not exactly sure when or why, but this will accept any dimension as long as it only contains one value

Resolves #384
Resolves https://github.com/comfyanonymous/ComfyUI/issues/11542