### PR TITLE
Added support to load model config from Metadata.

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -165,9 +165,9 @@ class UnetLoaderGGUF:
 
         # init model
         unet_path = folder_paths.get_full_path("unet", unet_name)
-        sd, metadata = gguf_sd_loader(unet_path)
+        sd, extra = gguf_sd_loader(unet_path)
         model = comfy.sd.load_diffusion_model_state_dict(
-            sd, model_options={"custom_operations": ops}, metadata=metadata
+            sd, model_options={"custom_operations": ops}, metadata=extra.get("metadata", {})
         )
         if model is None:
             logging.error("ERROR UNSUPPORTED UNET {}".format(unet_path))

--- a/nodes.py
+++ b/nodes.py
@@ -165,9 +165,9 @@ class UnetLoaderGGUF:
 
         # init model
         unet_path = folder_paths.get_full_path("unet", unet_name)
-        sd = gguf_sd_loader(unet_path)
+        sd, metadata = gguf_sd_loader(unet_path)
         model = comfy.sd.load_diffusion_model_state_dict(
-            sd, model_options={"custom_operations": ops}
+            sd, model_options={"custom_operations": ops}, metadata=metadata
         )
         if model is None:
             logging.error("ERROR UNSUPPORTED UNET {}".format(unet_path))
@@ -319,3 +319,4 @@ NODE_CLASS_MAPPINGS = {
     "QuadrupleCLIPLoaderGGUF": QuadrupleCLIPLoaderGGUF,
     "UnetLoaderGGUFAdvanced": UnetLoaderGGUFAdvanced,
 }
+


### PR DESCRIPTION
The Diffusion Loader in ComfyUI can read the model config directly from the safetensors metadata. I’ve added the same support, so newer models like LTX2 are handled correctly, since ComfyUI loads the model configuration for LTX2 from the safetensors file header metadata.