### PR TITLE
Add Gemma3 12B Support

### DIFF
--- a/loader.py
+++ b/loader.py
@@ -492,7 +492,7 @@ def gguf_clip_loader(path):
             if arch == "llama" and sd[temb_key].shape == (131072, 5120):
                 # non-standard Comfy-Org tokenizer
                 sd["tekken_model"] = gguf_tekken_tokenizer_loader(path, sd[temb_key].shape)
-            if arch == "gemma3":
+            elif arch == "gemma3":
                 sd["spiece_model"] = gguf_gemma3_tokenizer_loader(path)
             # See note above for T5.
             logging.warning(f"Dequantizing {temb_key} to prevent runtime OOM.")

--- a/loader.py
+++ b/loader.py
@@ -496,4 +496,3 @@ def gguf_clip_loader(path):
     else:
         pass
     return sd
-


### PR DESCRIPTION
Trying to add support for Gemma 3 12B GGUF, it can be used with the `DualClipLoader (GGUF)` node.

CLIP 1 is a Gemma 3 GGUF, and CLIP 2 uses embedding connectors from: https://huggingface.co/Kijai/LTXV2_comfy/tree/main/text_encoders

Note: The connectors from @kijai seem to come from the distilled models, and when testing it shows different results compared to connectors extracted from the dev models. ~~I’ve uploaded the connectors-dev here: https://huggingface.co/jayn7/LTXV2/tree/main if anyone want try it~~. Kijai has updated the repo and now provides both dev and distilled connectors.

<img width="1920" height="1080" alt="chrome_iVsVdBcPKv" src="https://github.com/user-attachments/assets/f79f6c44-7537-4fbf-af6c-d405e45a3b86" />

~~This approach uses the Gemma 3 `tokenizer.model` (4.5MB) file directly, instead of attempting to recreate tokenizer from metadata. It loads and searches for `tokenizer.model` or `gemma3-tokenizer.model` inside `ComfyUI/models/text_encoders` folder.
The tokenizer can be found here: https://huggingface.co/google/gemma-3-12b-it/tree/main~~

Edit: We no longer need `tokenizer.model`, the approach is the same as the others, it will attempt to recreate the tokenizer from metadata. https://github.com/city96/ComfyUI-GGUF/pull/402#issuecomment-3735608909

GGUF quants tested so far, but as long as they contain the required metadata, any release should work fine:
https://huggingface.co/unsloth/gemma-3-12b-it-GGUF - IQ4_XS
https://huggingface.co/bartowski/google_gemma-3-12b-it-GGUF - Q8 & BF16
https://huggingface.co/google/gemma-3-12b-it-qat-q4_0-gguf

Some example results (workflow embedded)

LTX 2.0 DEV T2V
| # | Description |  Result (video) |
|---|--------------|----------------|
| 1 | ComfyUI LTXV Audio Text Encoder Node (gemma_3_12B_it_bf16.safetensors) | <video src="https://github.com/user-attachments/assets/ba081abe-598b-4510-9474-fd938b38ae61" controls muted loop></video> |
| 2 | DualClipLoader GGUF Node (Gemma3 GGUF Q8 + embedding connectors extracted from dev models) | <video src="https://github.com/user-attachments/assets/795ef20f-67e1-4cdf-a5cc-67c0baeea555" controls muted loop></video> |
| 3 | DualClipLoader GGUF Node (Gemma3 GGUF Q8 + embedding connectors by kijai) | <video src="https://github.com/user-attachments/assets/2d73d09a-0d6a-4c28-a149-798b354fe15b" controls muted loop></video> |

LTX 2.0 Distilled T2V
| # | Description |  Result (video) |
|---|--------------|----------------|
| 1 | ComfyUI LTXV Audio Text Encoder Node (gemma_3_12B_it_bf16.safetensors) | <video src="https://github.com/user-attachments/assets/a159c71a-a8ff-4ebe-83ea-f0a7395f0991" controls muted loop></video> |
| 2 | DualClipLoader GGUF Node (Gemma3 GGUF Q8 + embedding connectors) | <video src="https://github.com/user-attachments/assets/a0b18cf8-5cc6-4e75-aa8a-b8afd0a898cd" controls muted loop></video> |

LTX 2.0 DEV I2V
| # | Description |  Result (video) |
|---|--------------|----------------|
| 1 | ComfyUI LTXV Audio Text Encoder Node (gemma_3_12B_it_bf16.safetensors) | <video src="https://github.com/user-attachments/assets/90ece427-6cf7-4fad-9b9b-c7d23d0c82c7" controls muted loop></video> |
| 2 | DualClipLoader GGUF Node (Gemma3 GGUF IQ4_XS + embedding connectors) | <video src="https://github.com/user-attachments/assets/4d783fe2-7318-4f80-acb1-20c892d42d60" controls muted loop></video> |