### PR TITLE
nodes: skip self.model.to(device_to) walk in unpatch_model on mmap'd weights

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -74,8 +74,29 @@ class GGUFModelPatcher(comfy.model_patcher.ModelPatcher):
                 patches = getattr(p, "patches", [])
                 if len(patches) > 0:
                     p.patches = []
-        # TODO: Find another way to not unload after patches
-        return super().unpatch_model(device_to=device_to, unpatch_weights=unpatch_weights)
+            # Restore non-quantized backups locally so we can short-circuit
+            # super()'s weight-unpatch block — its self.model.to(device_to)
+            # walk crashes with a Windows access violation on the still-mmap'd
+            # quantized tensors (#444). The maintainer's previous mitigation
+            # (Sep 2024 commit 6dbb4ba, reverted in 717a0e1) sidestepped the
+            # walk via device_to=None but skipped backup restoration, breaking
+            # LoRA correctness on subsequent runs (temp_weight in
+            # patch_weight_to_device reads the still-patched current weight).
+            # Doing the restore ourselves keeps non-quantized weights
+            # round-tripping correctly.
+            keys = list(self.backup.keys())
+            for k in keys:
+                bk = self.backup[k]
+                if bk.inplace_update:
+                    comfy.utils.copy_to_param(self.model, k, bk.weight)
+                else:
+                    comfy.utils.set_attr_param(self.model, k, bk.weight)
+            self.model.current_weight_patches_uuid = None
+            self.backup.clear()
+            for m in self.model.modules():
+                if hasattr(m, "comfy_patched_weights"):
+                    del m.comfy_patched_weights
+        return super().unpatch_model(device_to=device_to, unpatch_weights=False)
 
 
     def pin_weight_to_device(self, key):

--- a/nodes.py
+++ b/nodes.py
@@ -67,40 +67,31 @@ class GGUFModelPatcher(comfy.model_patcher.ModelPatcher):
             comfy.utils.set_attr_param(self.model, key, out_weight)
 
     def unpatch_model(self, device_to=None, unpatch_weights=True):
-        self.eject_model()
         if unpatch_weights:
             for p in self.model.parameters():
                 if is_torch_compatible(p):
                     continue
-                if len(getattr(p, "patches", [])) > 0:
+                patches = getattr(p, "patches", [])
+                if len(patches) > 0:
                     p.patches = []
-            # Mirror of base unpatch_model's unpatch_weights block, skipping the
-            # self.model.to(device_to) walk that faults on mmap'd quantized
-            # tensors (#444). Tracking upstream at Comfy-Org/ComfyUI#14142.
-            self.unpatch_hooks()
-            self.unpin_all_weights()
-            if self.model.model_lowvram:
+            if device_to is not None and self.model.model_lowvram:
                 for m in self.model.modules():
                     comfy.model_patcher.move_weight_functions(m, device_to)
-                    comfy.model_patcher.wipe_lowvram_weight(m)
-                self.model.model_lowvram = False
-                self.model.lowvram_patch_counter = 0
-            for k in list(self.backup.keys()):
-                bk = self.backup[k]
-                if bk.inplace_update:
-                    comfy.utils.copy_to_param(self.model, k, bk.weight)
-                else:
-                    comfy.utils.set_attr_param(self.model, k, bk.weight)
-            self.model.current_weight_patches_uuid = None
-            self.backup.clear()
-            if device_to is not None:
-                self.model.device = device_to
-            self.model.model_loaded_weight_memory = 0
-            self.model.model_offload_buffer_memory = 0
-            for m in self.model.modules():
-                if hasattr(m, "comfy_patched_weights"):
-                    del m.comfy_patched_weights
-        return super().unpatch_model(device_to=device_to, unpatch_weights=False)
+        # device_to=None makes base skip its nn.Module.to walk, which touches
+        # still-mmap'd quantized tensors (#444). The walk below only moves
+        # tensors that live on another device, so host-resident (possibly
+        # mmap-backed) memory is read at most, never written or remapped.
+        # Tracking upstream at Comfy-Org/ComfyUI#14142.
+        super().unpatch_model(device_to=None, unpatch_weights=unpatch_weights)
+        if unpatch_weights and device_to is not None:
+            device_to = torch.device(device_to)
+            for key, param in list(self.model.named_parameters(remove_duplicate=False)):
+                if param.device != device_to:
+                    comfy.utils.set_attr_param(self.model, key, param.to(device_to))
+            for key, buf in list(self.model.named_buffers(remove_duplicate=False)):
+                if buf.device != device_to:
+                    comfy.utils.set_attr(self.model, key, buf.to(device_to))
+            self.model.device = device_to
 
 
     def pin_weight_to_device(self, key):

--- a/nodes.py
+++ b/nodes.py
@@ -67,25 +67,25 @@ class GGUFModelPatcher(comfy.model_patcher.ModelPatcher):
             comfy.utils.set_attr_param(self.model, key, out_weight)
 
     def unpatch_model(self, device_to=None, unpatch_weights=True):
+        self.eject_model()
         if unpatch_weights:
             for p in self.model.parameters():
                 if is_torch_compatible(p):
                     continue
-                patches = getattr(p, "patches", [])
-                if len(patches) > 0:
+                if len(getattr(p, "patches", [])) > 0:
                     p.patches = []
-            # Restore non-quantized backups locally so we can short-circuit
-            # super()'s weight-unpatch block — its self.model.to(device_to)
-            # walk crashes with a Windows access violation on the still-mmap'd
-            # quantized tensors (#444). The maintainer's previous mitigation
-            # (Sep 2024 commit 6dbb4ba, reverted in 717a0e1) sidestepped the
-            # walk via device_to=None but skipped backup restoration, breaking
-            # LoRA correctness on subsequent runs (temp_weight in
-            # patch_weight_to_device reads the still-patched current weight).
-            # Doing the restore ourselves keeps non-quantized weights
-            # round-tripping correctly.
-            keys = list(self.backup.keys())
-            for k in keys:
+            # Mirror of base unpatch_model's unpatch_weights block, skipping the
+            # self.model.to(device_to) walk that faults on mmap'd quantized
+            # tensors (#444). Tracking upstream at Comfy-Org/ComfyUI#14142.
+            self.unpatch_hooks()
+            self.unpin_all_weights()
+            if self.model.model_lowvram:
+                for m in self.model.modules():
+                    comfy.model_patcher.move_weight_functions(m, device_to)
+                    comfy.model_patcher.wipe_lowvram_weight(m)
+                self.model.model_lowvram = False
+                self.model.lowvram_patch_counter = 0
+            for k in list(self.backup.keys()):
                 bk = self.backup[k]
                 if bk.inplace_update:
                     comfy.utils.copy_to_param(self.model, k, bk.weight)
@@ -93,6 +93,10 @@ class GGUFModelPatcher(comfy.model_patcher.ModelPatcher):
                     comfy.utils.set_attr_param(self.model, k, bk.weight)
             self.model.current_weight_patches_uuid = None
             self.backup.clear()
+            if device_to is not None:
+                self.model.device = device_to
+            self.model.model_loaded_weight_memory = 0
+            self.model.model_offload_buffer_memory = 0
             for m in self.model.modules():
                 if hasattr(m, "comfy_patched_weights"):
                     del m.comfy_patched_weights


### PR DESCRIPTION
Resolves #444.

`GGUFModelPatcher.unpatch_model` forwards to base `ModelPatcher.unpatch_model`, which finishes its `unpatch_weights=True` block with `self.model.to(device_to)`. That walk uses `nn.Module.to` and iterates every parameter, ignoring `comfy_cast_weights = True` on `GGMLLayer`. The walk hits the still-mmap'd quantized tensors and faults with `EXCEPTION_ACCESS_VIOLATION` on Windows. Repro: any workflow that triggers a cached-patcher flush during sampling (e.g. a `UnetLoaderGGUF` wired into a multi-output node).

The cleanest fix is upstream, since the same conflict will hit any custom op that uses `comfy_cast_weights` with tensors that cannot survive `nn.Module.to`. Tracked at Comfy-Org/ComfyUI#14142.

In the meantime this override inlines base's `unpatch_weights=True` block and skips just that one line. The block has to run in full because `partially_load` reads `model_loaded_weight_memory` immediately after `unpatch_model` and short-circuits `self.load()` if it is nonzero - so a partial mirror (the previous attempt at this PR) left `.patches` cleared without re-attaching anything on LoRA strength changes (caught by @romybaby on this thread). The lines this override now runs map one-for-one to comfy's `model_patcher.py` body:

- `eject_model`
- `unpatch_hooks`, `unpin_all_weights`
- lowvram cleanup via `move_weight_functions` / `wipe_lowvram_weight`
- non-quantized backup restoration
- `current_weight_patches_uuid = None`, `backup.clear()`
- `model_loaded_weight_memory = 0`, `model_offload_buffer_memory = 0`
- `comfy_patched_weights` deletion per module
- final `super().unpatch_model(unpatch_weights=False)` for `eject_model` (idempotent) and `object_patches_backup` restoration

Drift risk noted: if upstream adds something to that block, this override needs a sync. Easier to spot since the structure now matches line for line.

Credit @stonerabit for the original repro and diagnosis on #444, and @romybaby for catching the LoRA strength-change regression in the previous iteration.