### PR TITLE
Add Ideogram-4 diffusion model architecture support

### DIFF
--- a/loader.py
+++ b/loader.py
@@ -9,7 +9,7 @@ import os
 from .ops import GGMLTensor
 from .dequant import is_quantized, dequantize_tensor
 
-IMG_ARCH_LIST = {"flux", "sd1", "sdxl", "sd3", "aura", "hidream", "cosmos", "ltxv", "hyvid", "wan", "lumina2", "qwen_image"}
+IMG_ARCH_LIST = {"flux", "sd1", "sdxl", "sd3", "aura", "hidream", "cosmos", "ltxv", "hyvid", "wan", "lumina2", "qwen_image", "ideogram4"}
 TXT_ARCH_LIST = {"t5", "t5encoder", "llama", "qwen2vl", "qwen3", "qwen3vl", "gemma3"}
 VIS_TYPE_LIST = {"clip-vision", "mmproj"}
 

--- a/tools/convert.py
+++ b/tools/convert.py
@@ -145,8 +145,15 @@ class ModelLumina2(ModelTemplate):
         ("cap_embedder.1.weight", "context_refiner.0.attention.qkv.weight")
     ]
 
-arch_list = [ModelFlux, ModelSD3, ModelAura, ModelHiDream, CosmosPredict2, 
-             ModelLTXV, ModelHyVid, ModelWan, ModelSDXL, ModelSD1, ModelLumina2]
+class ModelIdeogram4(ModelTemplate):
+    arch = "ideogram4"
+    keys_detect = [
+        ("embed_image_indicator.weight", "input_proj.weight", "layers.0.attention.qkv.weight")
+    ]
+
+arch_list = [ModelFlux, ModelSD3, ModelAura, ModelHiDream, CosmosPredict2,
+             ModelLTXV, ModelHyVid, ModelWan, ModelSDXL, ModelSD1, ModelLumina2,
+             ModelIdeogram4]
 
 def is_model_arch(model, state_dict):
     # check if model is correct


### PR DESCRIPTION
ComfyUI core already ships Ideogram-4 support, but the GGUF loader does not recognise the architecture, so its GGUF files fail with `Unknown model architecture!`. This adds the missing detection layer.

### Changes
- `tools/convert.py`: a `ModelIdeogram4` template, detected by the combination of `embed_image_indicator.weight` (the same discriminator core uses), `input_proj.weight` and `layers.0.attention.qkv.weight`.
- `loader.py`: `"ideogram4"` added to `IMG_ARCH_LIST`.

### Notes
- No tensor remapping is required: the GGUF tensor names already match `comfy/ldm/ideogram4/model.py`.
- No new quantisation support is needed: the files in circulation use BF16, Q8_0 and IQ4_NL, all already handled by `dequant.py`.
- Follows the pattern of the existing architecture additions (Wan, HiDream, Cosmos, Qwen3, Gemma3).

### Context
There is no official Ideogram-4 GGUF yet; the available files (stduhpf, leejet) are sd.cpp-style exports without `general.architecture` metadata, which fall through to `detect_arch`. This change is what allows that path to resolve.

### Testing
Verified on Apple Silicon (M-series, MPS, torch 2.12): `detect_arch` returns `ideogram4`, the model loads in sd.cpp compatibility mode and generates end to end.

Part of #454.

*Developed with AI assistance; the diff and test results above were verified on-device before submission.*
