### PR TITLE
Report a float compute dtype for quantized GGMLTensor

### DIFF
--- a/ops.py
+++ b/ops.py
@@ -90,6 +90,19 @@ class GGMLTensor(torch.Tensor):
             self.tensor_shape = self.size()
         return self.tensor_shape
 
+    @property
+    def dtype(self):
+        # Quantized weights are stored as packed uint8; some models (e.g. Ideogram-4)
+        # do `x.to(weight.dtype)`, which would corrupt activations and break MPS
+        # (linear requires float inputs). Report a float compute dtype for quantized
+        # tensors; F16/F32/unquantized report their real storage dtype.
+        tt = getattr(self, "tensor_type", None)
+        if tt not in (None, gguf.GGMLQuantizationType.F32, gguf.GGMLQuantizationType.F16):
+            # bf16 (not fp16) avoids downcast/saturation on GGML-BF16 models (WAN/FLUX
+            # run bf16 native). compute_dtype, if set by the loader, takes precedence.
+            return getattr(self, "compute_dtype", None) or torch.bfloat16
+        return torch.Tensor.dtype.__get__(self)
+
 class GGMLLayer(torch.nn.Module):
     """
     This (should) be responsible for de-quantizing on the fly


### PR DESCRIPTION
A quantized `GGMLTensor` is backed by packed uint8 storage, so `weight.dtype` returns `torch.uint8`. Models that cast activations to the weight dtype before a linear (Ideogram-4 `ldm/ideogram4/model.py`, Gemma-4, Qwen3.5, CogVideo, some VAEs do `x.to(weight.dtype)`) therefore convert their activations to uint8. This corrupts them and breaks `F.linear` on MPS, which requires floating-point inputs: `RuntimeError: MPS device does not support linear for non-float inputs`.

### Change
`GGMLTensor.dtype` now returns a floating-point compute dtype (`bfloat16`) for quantised tensors; F16, F32 and unquantised tensors keep their real storage dtype. A `compute_dtype` set by the loader takes precedence.

- `bfloat16` rather than `float16` avoids downcast and saturation on GGML-BF16 models, which run bfloat16 natively (WAN, FLUX).
- The dequantisation paths are unaffected, as they read storage through `.data` rather than `.dtype`.

### Testing
- Fixes Ideogram-4 GGUF generation on MPS, which previously failed in the DiT forward pass.
- Regression-tested by loading WAN 2.2 I2V A14B Q8_0 (1095 tensors) on MPS: dequantisation shape and values are correct, the forward pass runs end to end, and there is no recursion in the property.

The change mainly benefits MPS, where the non-float cast is fatal; CUDA tolerated the previous behaviour.

Part of #454.

*Developed with AI assistance; the diff and test results above were verified on-device before submission.*
