### PR TITLE
Add Ideogram 4 architecture support

### DIFF
--- a/loader.py
+++ b/loader.py
@@ -9,7 +9,7 @@ import os
 from .ops import GGMLTensor
 from .dequant import is_quantized, dequantize_tensor
 
-IMG_ARCH_LIST = {"flux", "sd1", "sdxl", "sd3", "aura", "hidream", "cosmos", "ltxv", "hyvid", "wan", "lumina2", "qwen_image"}
+IMG_ARCH_LIST = {"flux", "sd1", "sdxl", "sd3", "aura", "hidream", "cosmos", "ltxv", "hyvid", "wan", "lumina2", "qwen_image", "ideogram4"}
 TXT_ARCH_LIST = {"t5", "t5encoder", "llama", "qwen2vl", "qwen3", "qwen3vl", "gemma3"}
 VIS_TYPE_LIST = {"clip-vision", "mmproj"}
 

--- a/tools/convert.py
+++ b/tools/convert.py
@@ -145,8 +145,15 @@ class ModelLumina2(ModelTemplate):
         ("cap_embedder.1.weight", "context_refiner.0.attention.qkv.weight")
     ]
 
+class ModelIdeogram4(ModelTemplate):
+    arch = "ideogram4"
+    keys_detect = [
+        ("embed_image_indicator.weight", "llm_cond_proj.weight", "layers.0.adaln_modulation.weight"),
+        ("embed_image_indicator.weight", "input_proj.weight", "adaln_proj.weight"),
+    ]
+
 arch_list = [ModelFlux, ModelSD3, ModelAura, ModelHiDream, CosmosPredict2, 
-             ModelLTXV, ModelHyVid, ModelWan, ModelSDXL, ModelSD1, ModelLumina2]
+             ModelLTXV, ModelHyVid, ModelWan, ModelSDXL, ModelSD1, ModelLumina2, ModelIdeogram4]
 
 def is_model_arch(model, state_dict):
     # check if model is correct


### PR DESCRIPTION
Adds support for loading Ideogram 4 GGUF models.

## Changes

- **loader.py**: Add ideogram4 to IMG_ARCH_LIST
- **tools/convert.py**: Add ModelIdeogram4 class for tensor-name-based fallback detection (for sd.cpp GGUF files without general.architecture metadata)

## Testing

Tested with Ideogram 4 Q6_K and Q8_0 GGUF files. Models load and run successfully.