### PR TITLE
Handle WeightAdapters in ops.move_patch_to_device

### DIFF
--- a/ops.py
+++ b/ops.py
@@ -8,6 +8,11 @@ import comfy.lora
 import comfy.model_management
 from .dequant import dequantize_tensor, is_quantized
 
+try:
+    import comfy.weight_adapter as wadapter
+except (ImportError, ModuleNotFoundError):
+    wadapter = None
+
 def chained_hasattr(obj, chained_attr):
     probe = obj
     for attr in chained_attr.split('.'):
@@ -270,12 +275,28 @@ class GGMLOps(comfy.ops.manual_cast):
             weight, bias = self.cast_bias_weight(input)
             return torch.nn.functional.group_norm(input, self.num_groups, weight, bias, self.eps)
 
-def move_patch_to_device(item, device):
-    if isinstance(item, torch.Tensor):
-        return item.to(device, non_blocking=True)
-    elif isinstance(item, tuple):
-        return tuple(move_patch_to_device(x, device) for x in item)
-    elif isinstance(item, list):
-        return [move_patch_to_device(x, device) for x in item]
-    else:
+def move_patch_to_device(item, device, *, dtype=None):
+    if device is None:
         return item
+    if isinstance(item, torch.Tensor):
+        return comfy.model_management.cast_to_device(item, device, dtype, copy=True)
+    if isinstance(item, (tuple, list)):
+        return item.__class__(
+            move_patch_to_device(seqitem, device, dtype=dtype) for seqitem in item
+        )
+    if (
+        wadapter is not None
+        and isinstance(item, wadapter.WeightAdapterBase)
+        and hasattr(item, "loaded_keys")
+        and isinstance(getattr(item, "weights", None), (tuple, list))
+    ):
+        return item.__class__(
+            item.loaded_keys,
+            item.weights.__class__(
+                wi
+                if not isinstance(wi, torch.Tensor)
+                else comfy.model_management.cast_to_device(wi, device, dtype, copy=True)
+                for wi in item.weights
+            ),
+        )
+    return item


### PR DESCRIPTION
`move_patch_to_device` hasn't done anything in a really long time since patches are basically never bare `torch.Tensor` instances anymore and are instances of `WeightAdapterBase` instead. The current `move_patch_to_device` is a no-op.

I am not positive this approach is the correct one or will handle something like an exotic custom instance of the weight adapter base class that behaves differently. I have been using it in my local version for months now without any problems.

`model_management.cast_to_device` automatically determines of non-blocking transfers are supported and enables that when appropriate. `copy=true` might not be necessary, but it seemed like the safe choice. I haven't tried with that disabled.

Note: I said this works for me but I have been using it/testing with other local patches like the Triton kernels. I don't see how that could make a difference but like the jerk I am, I haven't actually tested it in a vanilla setup.