### PR TITLE
Fix loading of BF16 bare nn.Parameters (LTX-2 learnable_registers)

### DIFF
--- a/loader.py
+++ b/loader.py
@@ -142,6 +142,12 @@ def gguf_sd_loader(path, handle_prefix="model.diffusion_model.", is_text_model=F
         if len(shape) <= 1 and tensor.tensor_type == gguf.GGMLQuantizationType.BF16:
             state_dict[sd_key] = dequantize_tensor(state_dict[sd_key], dtype=torch.float32)
 
+        # GGMLLayer only intercepts weight/bias, so anything else (e.g. bare
+        # nn.Parameters such as LTX-2's learnable_registers) reaches torch's
+        # default load path and must already be a real float tensor.
+        elif not sd_key.endswith((".weight", ".bias")) and is_quantized(state_dict[sd_key]):
+            state_dict[sd_key] = dequantize_tensor(state_dict[sd_key], dtype=torch.float32)
+
         # keep track of loaded tensor types
         tensor_type_str = getattr(tensor.tensor_type, "name", repr(tensor.tensor_type))
         qtype_dict[tensor_type_str] = qtype_dict.get(tensor_type_str, 0) + 1


### PR DESCRIPTION
## Problem

LTX-2 GGUFs (`sulphur-2-distilled`, `ltx-2.3-*`) fail to load:

```
RuntimeError: Error(s) in loading state_dict for LTXAVModel:
  While copying the parameter named "audio_embeddings_connector.learnable_registers",
  whose dimensions in the model are torch.Size([128, 2048]) and whose dimensions in
  the checkpoint are torch.Size([128, 4096]), an exception occurred :
  ('only Tensors of floating point dtype can require gradients',).
```

## Root cause

`learnable_registers` is a bare `nn.Parameter` on a plain module (`comfy/ldm/lightricks/embeddings_connector.py`), not a Linear/Conv/Embedding/LayerNorm. `GGMLOps` never wraps it, so `GGMLLayer._load_from_state_dict` never runs and it reaches torch's default path, which builds a `Parameter(..., requires_grad=...)`.

These tensors are BF16. `loader.py` only reshapes F32/F16, so BF16 stays as the raw uint8 mmap buffer — 2 bytes/element, hence the doubled last dim. The BF16 rescue directly below only covers `len(shape) <= 1`, and these are 2D. Torch therefore receives uint8 and raises.

The reported dim mismatch is a red herring: `GGMLTensor.shape` returns the logical shape (so torch's shape check passes), while the error text prints `input_param.size()` — the raw byte size.

## Fix

`GGMLLayer` can only ever intercept `weight`/`bias` — everything else goes to `unexpected_keys`. So any other key must reach torch as a real float tensor.

## Testing

On `sulphur-2-distilled-Q4_K_M.gguf` (arch `ltxv`, 4444 tensors):

- Changes **exactly 2 tensors**. Of 292 non-weight/bias keys, 290 are F32 (skipped by the `is_quantized` guard) and 2 are the BF16 registers.
- ~3 MB fp32 in a 14.1 GB model; 1772 tensors remain lazily quantized.
- `UnetLoaderGGUF` now loads `LTXAVModel`; registers land as bfloat16 at `(128, 2048)` / `(128, 4096)`.
- Other archs unaffected — their non-weight/bias keys are F32, so `is_quantized` is False.

## Note

#392 addresses this same class of bug for lumina2 by matching key names. Happy to narrow this to `learnable_registers` specifically if you'd prefer the surgical approach.
