### PR TITLE
feat(ops): add GGMLTensor.dequantize() for generic core cast path

### DIFF
--- a/ops.py
+++ b/ops.py
@@ -90,6 +90,21 @@ class GGMLTensor(torch.Tensor):
             self.tensor_shape = self.size()
         return self.tensor_shape
 
+    def dequantize(self, dtype=None):
+        """Return a plain (un-packed) torch.Tensor of the real weights.
+
+        ComfyUI core's generic ``comfy.ops.cast_bias_weight`` only dequantizes
+        ``QuantizedTensor`` weights, so a GGUF ``GGMLTensor`` slips through
+        un-dequantized and reaches ``F.linear`` with its block-packed storage
+        shape, which crashes on a shape mismatch. Exposing this method lets the
+        generic path dequantize GGUF weights the same way ``GGMLLayer.get_weight``
+        already does, without core having to know about the GGUF types.
+        """
+        dt = dtype if dtype is not None else torch.float32
+        w = dequantize_tensor(self, dt, None)
+        # prevent propagating the custom tensor class
+        return torch.Tensor(w)
+
 class GGMLLayer(torch.nn.Module):
     """
     This (should) be responsible for de-quantizing on the fly


### PR DESCRIPTION
## What

Expose a `dequantize(dtype=None)` method on `GGMLTensor` that delegates to
`dequantize_tensor`, mirroring what `GGMLLayer.get_weight` already does.

This lets ComfyUI core's generic `comfy.ops.cast_bias_weight` dequantize GGUF
weights instead of leaking the block-packed storage into matmul, which crashes
on a shape mismatch for e.g. Qwen2.5-VL `generate()`:

    RuntimeError: mat1 and mat2 shapes cannot be multiplied (1x3584 and 2940x152064)

## Why duck-typed

Core's `cast_bias_weight` only handles `QuantizedTensor`. Rather than have core
import GGUF types, we expose `dequantize()` here and core checks for it by duck
typing (see Comfy-Org/ComfyUI#__CORE_PR__).

## Verification

Paired with the core change, loading a real Qwen2.5-VL GGUF clip and calling
the unmodified `transformer.logits` returns `(1, 1, 152064)` instead of crashing.
