### PR TITLE
Ensure force_patch_weights is set when partially loading/unloading models

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -89,6 +89,12 @@ class GGUFModelPatcher(comfy.model_patcher.ModelPatcher):
     mmap_released = False
     named_modules_to_munmap = {}
 
+    def partially_unload(self, *args, force_patch_weights=False, **kwargs):
+        return super().partially_unload(*args, force_patch_weights=True, **kwargs)
+
+    def partially_load(self, *args, force_patch_weights=False, **kwargs):
+        return super().partially_load(*args, force_patch_weights=True, **kwargs)
+
     def load(self, *args, force_patch_weights=False, **kwargs):
         if not self.mmap_released:
             self.named_modules_to_munmap = dict(self.model.named_modules())


### PR DESCRIPTION
The custom `GGUFModelPatcher` sets `force_patch_weights` to the load method so ComfyUI won't try to create low-VRAM patches for LoRAs, etc. However, it doesn't set that parameter for the partial load/unload methods (which default to `force_patch_weights=False`). This results in ComfyUI trying to create model weight functions to apply the LoRAs.

With the way the ops and patcher are set up in the official repo, those weight functions get ignored. However, we can skip the overhead of having ComfyUI create patches that are never going to get applied. You can confirm that ComfyUI is creating those weight functions that will never be applied since the log output dumps the low-VRAM patch count when the model gets loaded.