### PR TITLE
Add minimax_h3 to IMG_ARCH_LIST

### DIFF
--- a/loader.py
+++ b/loader.py
@@ -9,7 +9,7 @@ import os
 from .ops import GGMLTensor
 from .dequant import is_quantized, dequantize_tensor
 
-IMG_ARCH_LIST = {"flux", "sd1", "sdxl", "sd3", "aura", "hidream", "cosmos", "ltxv", "hyvid", "wan", "lumina2", "qwen_image"}
+IMG_ARCH_LIST = {"flux", "sd1", "sdxl", "sd3", "aura", "hidream", "cosmos", "ltxv", "hyvid", "wan", "lumina2", "qwen_image", "minimax_h3"}
 TXT_ARCH_LIST = {"t5", "t5encoder", "llama", "qwen2vl", "qwen3", "qwen3vl", "gemma3"}
 VIS_TYPE_LIST = {"clip-vision", "mmproj"}
 


### PR DESCRIPTION
MiniMax H3 UNet GGUFs that set `general.architecture = "minimax_h3"` are rejected by the loader:

```
ValueError: Unexpected architecture type in GGUF file: 'minimax_h3'
```

ComfyUI has native H3 support (`comfy/ldm/minimax/`, `comfy_extras/nodes_minimax_h3.py`), and the Qwen3-VL text encoder already loads because `qwen3vl` is in `TXT_ARCH_LIST` — only the diffusion model side is blocked.

Of the two community repacks I tested, `minimax_h3_fl2va_pruned_fp8_Q4_0.gguf` declares `minimax_h3` and fails, while `MiniMax-H3-FL2VA-Q3_K_M.gguf` declares `wan` and loads. So at present the list only accepts H3 files that are mislabeled.

Tested on ComfyUI 0.33.0 with the pruned fp8 Q4_0 repack; text-to-video and image-to-video both generate correctly with this change.
