### PR TITLE
Fix KeyError: 'default_num_special_tokens' when recreating Tekken tok…

### DIFF
--- a/loader.py
+++ b/loader.py
@@ -395,7 +395,7 @@ def gguf_tekken_tokenizer_loader(path, temb_shape):
     if model_str == "gpt2":
         if temb_shape == (131072, 5120): # probably Mistral
             data = {
-                "config": {"num_vocab_tokens": 150000, "default_vocab_size": 131072},
+                "config": {"num_vocab_tokens": 150000, "default_vocab_size": 131072, "default_num_special_tokens": 1000},
                 "vocab": [],
                 "special_tokens": [],
             }


### PR DESCRIPTION
…enizer

### Problem
When loading Mistral-based GGUF text encoders via `CLIPLoaderGGUF` (specifically tested with `Mistral-Small-3.2-24B-Instruct-2506-UD-Q8_K_XL.gguf` for FLUX.2 workflows), ComfyUI core crashes during tokenizer initialization:

```text
File "ComfyUI/comfy/text_encoders/bpe_tokenizer.py", line 271, in from_tekken_json
    special_token_offset = config["default_num_special_tokens"]
KeyError: 'default_num_special_tokens'