### PR TITLE
Add MiniMax H3 architecture detection for metadata-less GGUF files

### DIFF
--- a/loader.py
+++ b/loader.py
@@ -9,7 +9,7 @@ import os
 from .ops import GGMLTensor
 from .dequant import is_quantized, dequantize_tensor
 
-IMG_ARCH_LIST = {"flux", "sd1", "sdxl", "sd3", "aura", "hidream", "cosmos", "ltxv", "hyvid", "wan", "lumina2", "qwen_image"}
+IMG_ARCH_LIST = {"flux", "sd1", "sdxl", "sd3", "aura", "hidream", "cosmos", "ltxv", "hyvid", "wan", "lumina2", "qwen_image", "minimax_h3"}
 TXT_ARCH_LIST = {"t5", "t5encoder", "llama", "qwen2vl", "qwen3", "qwen3vl", "gemma3"}
 VIS_TYPE_LIST = {"clip-vision", "mmproj"}
 

--- a/tools/convert.py
+++ b/tools/convert.py
@@ -145,8 +145,14 @@ class ModelLumina2(ModelTemplate):
         ("cap_embedder.1.weight", "context_refiner.0.attention.qkv.weight")
     ]
 
-arch_list = [ModelFlux, ModelSD3, ModelAura, ModelHiDream, CosmosPredict2, 
-             ModelLTXV, ModelHyVid, ModelWan, ModelSDXL, ModelSD1, ModelLumina2]
+class ModelMiniMaxH3(ModelTemplate):
+    arch = "minimax_h3"
+    keys_detect = [
+        ("adaln_t_table", "blocks.0.adaln_proj.linear.weight", "blocks.0.attn.qkv_proj.weight")
+    ]
+
+arch_list = [ModelFlux, ModelSD3, ModelAura, ModelHiDream, CosmosPredict2,
+             ModelLTXV, ModelHyVid, ModelWan, ModelSDXL, ModelSD1, ModelLumina2, ModelMiniMaxH3]
 
 def is_model_arch(model, state_dict):
     # check if model is correct


### PR DESCRIPTION
# PR/Issue draft — city96/ComfyUI-GGUF

> 配合 `minimax_h3_gguf_support.patch` 一起提交到 https://github.com/city96/ComfyUI-GGUF
> 以下为可直接粘贴的英文说明。

---

**Title:** Add MiniMax H3 architecture detection for metadata-less GGUF files

## Problem

Community GGUF conversions of the MiniMax H3 video DiT (e.g. `unsloth/MiniMax-H3-GGUF`) ship without any metadata fields (`kv_count=0`, no `general.architecture`). Loading them falls back to tensor-name detection, which fails with:

```
ValueError: This model is not currently supported - (Unknown model architecture!)
```

## Change

Adds a `ModelMiniMaxH3` template detected by three keys unique to the H3 state dict layout — `adaln_t_table`, `blocks.0.adaln_proj.linear.weight`, `blocks.0.attn.qkv_proj.weight` — and registers `minimax_h3` in `IMG_ARCH_LIST`.

The detected names were verified to match the official Comfy-Org safetensors state dict exactly, so once detection passes, core ComfyUI model construction (`model_type FLOW_AV`) works unchanged. No collisions with existing templates (closest are `cosmos`'s `blocks.0.adaln_modulation_cross_attn.1.weight` and `wan`'s `blocks.0.self_attn.*`).

## Tested

- ComfyUI 0.34.0, PyTorch 2.9.1 (ROCm), `UnetLoaderGGUF` loading `minimax_h3_ref2va_pruned-Q4_K.gguf` (11.4 GB, 532 tensors): detection succeeds (`arch:minimax_h3`, loaded in sd.cpp compat mode), state dict keys match the native safetensors one-to-one.
- Existing arch detection paths untouched; patch only appends to `arch_list` / `IMG_ARCH_LIST`.
